### PR TITLE
Add schema normalization rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 dist
+example/bundle.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,29 +1,3 @@
 {
-    "rules": {
-        "no-extra-boolean-cast": [ 0 ],
-        "indent": [ 2, 4 ],
-        "quotes": [ 2, "single" ],
-        "linebreak-style": [ 2, "unix" ],
-        "semi": [ 2, "always" ],
-        "no-unused-vars": [ 2, {
-            "vars": "all",
-            "args": "none"
-        } ],
-        "spaced-comment": [ 2, "always" ]
-    },
-    "parserOptions": {
-        "ecmaVersion": 6,
-        "sourceType": "module",
-        "ecmaFeatures": {
-            "jsx": true,
-            "experimentalObjectRestSpread": true
-        }
-    },
-    "env": {
-        "node": true,
-        "browser": true,
-        "mocha": true,
-        "es6": true
-    },
-    "extends": "eslint:recommended"
+    "extends": "gitbook"
 }

--- a/README.md
+++ b/README.md
@@ -13,11 +13,20 @@ npm install slate-edit-list
 
 ### Features
 
+Classic keybindings:
+
 - Pressing <kbd>Enter</kbd> insert a new list item
 - Pressing <kbd>Shift+Enter</kbd> split the block in the list item
-- Pressing <kbd>Tab</kbd> wrap the item in a new list
-- Pressing <kbd>Shift+Tab</kbd> go up
+- Pressing <kbd>Tab</kbd> increase the depth of the item (creates a sub-list)
+- Pressing <kbd>Shift+Tab</kbd> decrease the depth of the item
 - Pressing <kbd>Delete</kbd> at the start, remove the list item (or the list)
+
+Simple validation/normalization:
+
+- Lists can contain only list items, and at least one.
+- List items can only be the direct children of a list.
+
+Useful transforms: see [Utilities and Transform](#utilities-and-transform).
 
 ### Simple Usage
 

--- a/example/main.js
+++ b/example/main.js
@@ -9,12 +9,14 @@ const plugins = [
     PluginEditList()
 ];
 
-const NODES = {
-    ul_list:   props => <ul {...props.attributes}>{props.children}</ul>,
-    ol_list:   props => <ol {...props.attributes}>{props.children}</ol>,
-    list_item: props => <li {...props.attributes}>{props.children}</li>,
-    paragraph: props => <p {...props.attributes}>{props.children}</p>,
-    heading:   props => <h1 {...props.attributes}>{props.children}</h1>
+const SCHEMA = {
+    nodes: {
+        ul_list:   props => <ul {...props.attributes}>{props.children}</ul>,
+        ol_list:   props => <ol {...props.attributes}>{props.children}</ol>,
+        list_item: props => <li {...props.attributes}>{props.children}</li>,
+        paragraph: props => <p {...props.attributes}>{props.children}</p>,
+        heading:   props => <h1 {...props.attributes}>{props.children}</h1>
+    }
 };
 
 const Example = React.createClass({
@@ -30,10 +32,6 @@ const Example = React.createClass({
         });
     },
 
-    renderNode: function(node) {
-        return NODES[node.type];
-    },
-
     render: function() {
         return (
             <Slate.Editor
@@ -41,7 +39,7 @@ const Example = React.createClass({
                 plugins={plugins}
                 state={this.state.state}
                 onChange={this.onChange}
-                renderNode={this.renderNode}
+                schema={SCHEMA}
             />
     );
     }

--- a/example/main.js
+++ b/example/main.js
@@ -20,19 +20,19 @@ const SCHEMA = {
 };
 
 const Example = React.createClass({
-    getInitialState: function() {
+    getInitialState() {
         return {
             state: Slate.Raw.deserialize(stateJson, { terse: true })
         };
     },
 
-    onChange: function(state) {
+    onChange(state) {
         this.setState({
-            state: state
+            state
         });
     },
 
-    render: function() {
+    render() {
         return (
             <Slate.Editor
                 placeholder={'Enter some text...'}

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ const unwrapList    = require('./transforms/unwrapList');
 const unwrapInList  = require('./transforms/unwrapInList');
 const splitListItem = require('./transforms/splitListItem');
 const getItemDepth  = require('./getItemDepth');
+const makeSchema    = require('./makeSchema');
 
 const KEY_ENTER     = 'enter';
 const KEY_TAB       = 'tab';
@@ -85,8 +86,12 @@ function EditList(opts) {
         }
     }
 
+    const schema = makeSchema(opts);
+
     return {
         onKeyDown,
+
+        schema,
 
         utils: {
             isSelectionInList,

--- a/lib/index.js
+++ b/lib/index.js
@@ -25,8 +25,8 @@ const KEY_BACKSPACE = 'backspace';
 
 function EditList(opts) {
     opts          = opts || {};
-    opts.typeUL   = opts.typeUL   || 'ul_list';
-    opts.typeOL   = opts.typeOL   || 'ol_list';
+    opts.typeUL   = opts.typeUL || 'ul_list';
+    opts.typeOL   = opts.typeOL || 'ol_list';
     opts.typeItem = opts.typeItem || 'list_item';
 
     /**
@@ -42,15 +42,14 @@ function EditList(opts) {
      * Bind a transform to be only applied in list
      */
     function bindTransform(fn) {
-        return function(transform) {
-            let { state } = transform;
-            let args = [].splice.call(arguments, 0);
+        return function(transform, ...args) {
+            const { state } = transform;
 
             if (!isSelectionInList(state)) {
                 return transform;
             }
 
-            return fn.apply(null, [opts].concat(args));
+            return fn(...[opts, transform].concat(args));
         };
     }
 
@@ -78,11 +77,11 @@ function EditList(opts) {
 
         switch (data.key) {
         case KEY_ENTER:
-            return onEnter.apply(null, args);
+            return onEnter(...args);
         case KEY_TAB:
-            return onTab.apply(null, args);
+            return onTab(...args);
         case KEY_BACKSPACE:
-            return onBackspace.apply(null, args);
+            return onBackspace(...args);
         }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,13 +15,17 @@ const KEY_BACKSPACE = 'backspace';
 
 /**
  * A Slate plugin to handle keyboard events in lists.
+ * @param {Object} [opts] Options for the plugin
+ * @param {String} [opts.typeUL='ul_list'] The type of unordered lists
+ * @param {String} [opts.typeOL='ol_list'] The type of ordered lists
+ * @param {String} [opts.typeItem='list_item'] The type of list items
  * @return {Object}
  */
 
 function EditList(opts) {
     opts          = opts || {};
-    opts.typeUL   = opts.typeUL || 'ul_list';
-    opts.typeOL   = opts.typeOL || 'ol_list';
+    opts.typeUL   = opts.typeUL   || 'ul_list';
+    opts.typeOL   = opts.typeOL   || 'ol_list';
     opts.typeItem = opts.typeItem || 'list_item';
 
     /**

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -32,7 +32,7 @@ function listsContainOnlyItems(opts) {
     return {
         match: isList,
 
-        validate (list) {
+        validate(list) {
             const items = list.nodes.filter(n => n.type === opts.typeItem);
 
             if (list.nodes.isEmpty() || items.isEmpty()) {
@@ -55,7 +55,7 @@ function listsContainOnlyItems(opts) {
          * Replaces the node's children
          * @param {List<Nodes>} value.nodes
          */
-        normalize (transform, node, value) {
+        normalize(transform, node, value) {
             return transform.setNodeByKey(node.key, {
                 nodes: value.nodes
             });
@@ -74,12 +74,12 @@ function itemsDescendList(opts) {
     const isList = matchTypes([opts.typeUL, opts.typeOL]);
 
     return {
-        match (node) {
+        match(node) {
             return (node.kind === 'block' || node.kind === 'document')
                 && !isList(node);
         },
 
-        validate (block) {
+        validate(block) {
             const listItems = block.nodes.filter(n => n.type === opts.typeItem);
 
             if (listItems.isEmpty()) {
@@ -97,7 +97,7 @@ function itemsDescendList(opts) {
          * Removes the given nodes
          * @param {List<Nodes>} value.toRemove
          */
-        normalize (transform, node, value) {
+        normalize(transform, node, value) {
             return value.toRemove.reduce(
                 (tr, node) => tr.removeNodeByKey(node.key),
                 transform

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -1,3 +1,4 @@
+const { Set } = require('immutable');
 const Slate = require('slate');
 
 /**
@@ -154,7 +155,7 @@ function itemsContainSingleBlock(opts) {
 function matchTypes(types) {
     types = new Set(types);
 
-    return node => types.some(type => type === node.type);
+    return (node) => types.some(type => type === node.type);
 }
 
 module.exports = makeSchema;

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -1,0 +1,160 @@
+const Slate = require('slate');
+
+/**
+ * Create a schema for lists
+ * @param {String} opts.typeUL The type of unordered lists
+ * @param {String} opts.typeOL The type of ordered lists
+ * @param {String} opts.typeItem The type of list items
+ * @return {Object} A schema definition with rules to normalize lists
+ */
+function makeSchema(opts) {
+    return {
+        rules: [
+            listsContainOnlyItems(opts),
+            itemsDescendList(opts),
+            itemsContainSingleBlock
+        ]
+    };
+}
+
+/**
+ * @param {String} opts.typeUL The type of unordered lists
+ * @param {String} opts.typeOL The type of ordered lists
+ * @param {String} opts.typeItem The type of list items
+ * @return {Object} A rule that ensure lists only contain list
+ * items, and at least one.
+ */
+function listsContainOnlyItems(opts) {
+    const EMPTY_LIST_ITEM = {
+        type: opts.typeItem
+    };
+    const isList = matchTypes([opts.typeUL, opts.typeOL]);
+
+    return {
+        match: isList,
+
+        validate (list) {
+            const items = list.nodes.filter(n => n.type === opts.typeItem);
+
+            if (list.nodes.isEmpty() || items.isEmpty()) {
+                // No list items
+                return {
+                    nodes: [EMPTY_LIST_ITEM]
+                };
+            } else if (list.nodes.size === items.size) {
+                // Only valid list items
+                return null;
+            } else {
+                // Keep only list items
+                return {
+                    nodes: items
+                };
+            }
+        },
+
+        /**
+         * Replaces the node's children
+         * @param {List<Nodes>} value.nodes
+         */
+        normalize (transform, node, value) {
+            return transform.setNodeByKey(node.key, {
+                nodes: value.nodes
+            });
+        }
+    };
+}
+
+/**
+ * @param {String} opts.typeUL The type of unordered lists
+ * @param {String} opts.typeOL The type of ordered lists
+ * @param {String} opts.typeItem The type of list items
+ * @return {Object} A rule that ensure list items are always children
+ * of a list block.
+ */
+function itemsDescendList(opts) {
+    const isList = matchTypes([opts.typeUL, opts.typeOL]);
+
+    return {
+        match (node) {
+            return (node.kind === 'block' || node.kind === 'document')
+                && !isList(node);
+        },
+
+        validate (block) {
+            const listItems = block.nodes.filter(n => n.type === opts.typeItem);
+
+            if (listItems.isEmpty()) {
+                // No orphan list items. All good.
+                return null;
+            } else {
+                // Remove the orphan list items
+                return {
+                    toRemove: listItems
+                };
+            }
+        },
+
+        /**
+         * Removes the given nodes
+         * @param {List<Nodes>} value.toRemove
+         */
+        normalize (transform, node, value) {
+            return value.toRemove.reduce(
+                (tr, node) => tr.removeNodeByKey(node.key),
+                transform
+            );
+        }
+    };
+}
+
+/**
+ * @param {String} opts.typeItem The type of list items
+ * @return {Object} A rule that ensure list items always contains a single block.
+ */
+function itemsContainSingleBlock(opts) {
+    return {
+        match: matchTypes([opts.typeItem]),
+
+        validate (node) {
+            const firstBlock = node.nodes.find(n => n.kind === 'block');
+
+            if (node.nodes.isEmpty() || firstBlock === null) {
+                // No block child, make one
+                return {
+                    nodes: [new Slate.Text()]
+                };
+            } else if (node.nodes.size === 1) {
+                // Just a block node -> valid
+                return null;
+            } else {
+                // Keep only the first block child
+                return {
+                    nodes: [firstBlock]
+                };
+            }
+        },
+
+        /**
+         * Replaces the node's children
+         * @param {List<Nodes>} value.nodes
+         */
+        normalize (transform, node, value) {
+            return transform.setNodeByKey(node.key, {
+                nodes: value.nodes
+            });
+        }
+    };
+}
+
+/**
+ * @param {Array<String>} types
+ * @return {Function} A function that returns true for nodes that
+ * match one of the given types.
+ */
+function matchTypes(types) {
+    types = new Set(types);
+
+    return node => types.some(type => type === node.type);
+}
+
+module.exports = makeSchema;

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -1,5 +1,4 @@
 const { Set } = require('immutable');
-const Slate = require('slate');
 
 /**
  * Create a schema for lists

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -12,8 +12,7 @@ function makeSchema(opts) {
     return {
         rules: [
             listsContainOnlyItems(opts),
-            itemsDescendList(opts),
-            itemsContainSingleBlock
+            itemsDescendList(opts)
         ]
     };
 }
@@ -104,45 +103,6 @@ function itemsDescendList(opts) {
                 (tr, node) => tr.removeNodeByKey(node.key),
                 transform
             );
-        }
-    };
-}
-
-/**
- * @param {String} opts.typeItem The type of list items
- * @return {Object} A rule that ensure list items always contains a single block.
- */
-function itemsContainSingleBlock(opts) {
-    return {
-        match: matchTypes([opts.typeItem]),
-
-        validate (node) {
-            const firstBlock = node.nodes.find(n => n.kind === 'block');
-
-            if (node.nodes.isEmpty() || firstBlock === null) {
-                // No block child, make one
-                return {
-                    nodes: [new Slate.Text()]
-                };
-            } else if (node.nodes.size === 1) {
-                // Just a block node -> valid
-                return null;
-            } else {
-                // Keep only the first block child
-                return {
-                    nodes: [firstBlock]
-                };
-            }
-        },
-
-        /**
-         * Replaces the node's children
-         * @param {List<Nodes>} value.nodes
-         */
-        normalize (transform, node, value) {
-            return transform.setNodeByKey(node.key, {
-                nodes: value.nodes
-            });
         }
     };
 }

--- a/lib/transforms/unwrapInList.js
+++ b/lib/transforms/unwrapInList.js
@@ -8,7 +8,7 @@ const getItemDepth = require('../getItemDepth');
  * @return {Transform} transform
  */
 function unwrapInList(opts, transform, ordered) {
-    let depth = getItemDepth(opts, transform.state);
+    const depth = getItemDepth(opts, transform.state);
 
     if (depth == 1) {
         return transform;

--- a/lib/transforms/wrapInList.js
+++ b/lib/transforms/wrapInList.js
@@ -9,7 +9,7 @@
  */
 function wrapInList(opts, transform, ordered) {
     return transform
-        .wrapBlock(ordered? opts.typeOL : opts.typeUL)
+        .wrapBlock(ordered ? opts.typeOL : opts.typeUL)
         .wrapBlock(opts.typeItem);
 }
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babelify": "^7.3.0",
     "browserify": "^13.1.0",
     "eslint": "^3.1.1",
-    "eslint-plugin-react": "^5.2.2",
+    "eslint-config-gitbook": "1.1.2",
     "expect": "^1.20.2",
     "gh-pages": "^0.11.0",
     "http-server": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "react": "^15.3.0",
     "react-dom": "^15.3.0",
     "read-metadata": "^1.0.0",
-    "slate": "^0.10.1",
+    "slate": "^0.13.6",
     "slate-edit-code": "^0.1.0"
   },
   "scripts": {

--- a/tests/schema-items-are-list-children/expected.yaml
+++ b/tests/schema-items-are-list-children/expected.yaml
@@ -1,0 +1,16 @@
+
+nodes:
+  - kind: block
+    type: ul_list
+    nodes:
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: text
+            text: "Valid item"
+      # Item that contains another item
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: text
+            text: ""

--- a/tests/schema-items-are-list-children/input.yaml
+++ b/tests/schema-items-are-list-children/input.yaml
@@ -1,0 +1,26 @@
+
+nodes:
+  # orphan item
+  - kind: block
+    type: list_item
+    nodes:
+      - kind: text
+        text: "Orphan"
+
+  - kind: block
+    type: ul_list
+    nodes:
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: text
+            text: "Valid item"
+      # Item that contains another item
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: list_item
+            nodes:
+              - kind: text
+                text: "Direct child of another item"

--- a/tests/schema-items-are-list-children/transform.js
+++ b/tests/schema-items-are-list-children/transform.js
@@ -1,0 +1,7 @@
+const Slate = require('slate');
+
+module.exports = function(plugin, state) {
+    const schema = new Slate.Schema(plugin.schema);
+    const normalized = state.normalize(schema);
+    return normalized;
+};

--- a/tests/schema-lists-contain-items/expected.yaml
+++ b/tests/schema-lists-contain-items/expected.yaml
@@ -1,0 +1,15 @@
+
+nodes:
+  - kind: block
+    type: ul_list
+    nodes:
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: text
+            text: "1st item"
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: text
+            text: "3rd item"

--- a/tests/schema-lists-contain-items/input.yaml
+++ b/tests/schema-lists-contain-items/input.yaml
@@ -1,0 +1,21 @@
+
+nodes:
+  - kind: block
+    type: ul_list
+    nodes:
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: text
+            text: "1st item"
+      # Does not contain only list items
+      - kind: block
+        type: default
+        nodes:
+          - kind: text
+            text: "2nd item"
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: text
+            text: "3rd item"

--- a/tests/schema-lists-contain-items/transform.js
+++ b/tests/schema-lists-contain-items/transform.js
@@ -1,0 +1,7 @@
+const Slate = require('slate');
+
+module.exports = function(plugin, state) {
+    const schema = new Slate.Schema(plugin.schema);
+    const normalized = state.normalize(schema);
+    return normalized;
+};

--- a/tests/schema-nested-lists/expected.yaml
+++ b/tests/schema-nested-lists/expected.yaml
@@ -1,0 +1,29 @@
+# Same as input
+nodes:
+  - kind: block
+    type: ol_list
+    nodes:
+      # Nested list
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: text
+            text: "Nested list"
+          - kind: block
+            type: ul_list
+            nodes:
+              - kind: block
+                type: list_item
+                nodes:
+                  - kind: text
+                    text: "1.1"
+              - kind: block
+                type: list_item
+                nodes:
+                  - kind: text
+                    text: "1.2"
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: text
+            text: "2"

--- a/tests/schema-nested-lists/input.yaml
+++ b/tests/schema-nested-lists/input.yaml
@@ -1,0 +1,29 @@
+
+nodes:
+  - kind: block
+    type: ol_list
+    nodes:
+      # Nested list
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: text
+            text: "Nested list"
+          - kind: block
+            type: ul_list
+            nodes:
+              - kind: block
+                type: list_item
+                nodes:
+                  - kind: text
+                    text: "1.1"
+              - kind: block
+                type: list_item
+                nodes:
+                  - kind: text
+                    text: "1.2"
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: text
+            text: "2"

--- a/tests/schema-nested-lists/transform.js
+++ b/tests/schema-nested-lists/transform.js
@@ -1,0 +1,7 @@
+const Slate = require('slate');
+
+module.exports = function(plugin, state) {
+    const schema = new Slate.Schema(plugin.schema);
+    const normalized = state.normalize(schema);
+    return normalized;
+};

--- a/tests/split-listitem-end/transform.js
+++ b/tests/split-listitem-end/transform.js
@@ -1,12 +1,12 @@
 
 module.exports = function(plugin, state) {
-    let p = state.document.findDescendant(node => node.type == 'paragraph');
+    const p = state.document.findDescendant(node => node.type == 'paragraph');
 
-    let withCursor = state.transform()
+    const withCursor = state.transform()
         .collapseToEndOf(p)
         .apply();
 
-    let transform = withCursor.transform();
+    const transform = withCursor.transform();
     return plugin.transforms
         .splitListItem(transform)
         .apply();

--- a/tests/split-listitem-offset/transform.js
+++ b/tests/split-listitem-offset/transform.js
@@ -1,13 +1,13 @@
 
 module.exports = function(plugin, state) {
-    let p = state.document.findDescendant(node => node.type == 'paragraph');
+    const p = state.document.findDescendant(node => node.type == 'paragraph');
 
-    let withCursor = state.transform()
+    const withCursor = state.transform()
         .collapseToStartOf(p)
         .moveToOffsets(5, 5)
         .apply();
 
-    let transform = withCursor.transform();
+    const transform = withCursor.transform();
     return plugin.transforms
         .splitListItem(transform)
         .apply();

--- a/tests/split-listitem-start/transform.js
+++ b/tests/split-listitem-start/transform.js
@@ -1,12 +1,12 @@
 
 module.exports = function(plugin, state) {
-    let p = state.document.findDescendant(node => node.type == 'paragraph');
+    const p = state.document.findDescendant(node => node.type == 'paragraph');
 
-    let withCursor = state.transform()
+    const withCursor = state.transform()
         .collapseToStartOf(p)
         .apply();
 
-    let transform = withCursor.transform();
+    const transform = withCursor.transform();
     return plugin.transforms
         .splitListItem(transform)
         .apply();

--- a/tests/unwrap-list/transform.js
+++ b/tests/unwrap-list/transform.js
@@ -1,6 +1,6 @@
 
 module.exports = function(plugin, state) {
-    let transform = state.transform();
+    const transform = state.transform();
     return plugin.transforms.unwrapList(transform)
         .apply();
 };

--- a/tests/wrap-in-list/transform.js
+++ b/tests/wrap-in-list/transform.js
@@ -1,6 +1,6 @@
 
 module.exports = function(plugin, state) {
-    let transform = state.transform();
+    const transform = state.transform();
     return plugin.transforms.wrapInList(transform)
         .apply();
 };

--- a/tests/wrap-in-ol/transform.js
+++ b/tests/wrap-in-ol/transform.js
@@ -1,6 +1,6 @@
 
 module.exports = function(plugin, state) {
-    let transform = state.transform();
+    const transform = state.transform();
     return plugin.transforms.wrapInList(transform, true)
         .apply();
 };


### PR DESCRIPTION
This adds a two simple rules that help validate and normalize a State containing lists.

1. List blocks must contain only List Items, and at least one.
2. List items can only be the children of List blocks.

For now, we don't put any rules on List Items's children, and consider they can contain a mix of Text and Block nodes. See https://github.com/GitbookIO/slate-edit-list/issues/3#issuecomment-243388107

