### PR TITLE
adds maxDepth option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,6 +27,7 @@ const KEY_BACKSPACE = 'backspace';
  * @param {String} [opts.typeOL='ol_list'] The type of ordered lists
  * @param {String} [opts.typeItem='list_item'] The type of list items
  * @param {String} [opts.typeDefault='paragraph'] The type of default block in items
+ * @param {Number} [opts.maxDepth=null] Maximum depth of nested lists
  * @return {Object}
  */
 

--- a/lib/transforms/increaseItemDepth.js
+++ b/lib/transforms/increaseItemDepth.js
@@ -3,6 +3,7 @@ const Slate = require('slate');
 const getPreviousItem = require('../getPreviousItem');
 const getCurrentItem = require('../getCurrentItem');
 const getCurrentList = require('../getCurrentList');
+const getItemDepth = require('../getItemDepth');
 const isList = require('../isList');
 
 /**
@@ -18,6 +19,12 @@ function increaseItemDepth(opts, transform) {
     const previousItem = getPreviousItem(opts, transform.state);
 
     if (!previousItem) {
+        return transform;
+    }
+
+    const previousItemDepth = getItemDepth(opts, transform.state, previousItem);
+
+    if (opts.maxDepth && (previousItemDepth - 1) > opts.maxDepth) {
         return transform;
     }
 


### PR DESCRIPTION
Simple little option to let users specify a max depth for items. I wouldn't want that behaviour in any schema validations or so, only when the user tries to increase the depth.
