### PR TITLE
Fix nesting with other containers

### DIFF
--- a/lib/getCurrentItem.js
+++ b/lib/getCurrentItem.js
@@ -15,9 +15,10 @@ function getCurrentItem(opts, state, block) {
         block = state.startBlock;
     }
 
-    return block.type === opts.typeItem
-        ? block
-        : document.getClosest(block.key, n => n.type === opts.typeItem);
+    const parent = document.getParent(block.key);
+    return (parent && parent.type === opts.typeItem)
+        ? parent
+        : null;
 }
 
 module.exports = getCurrentItem;

--- a/lib/getCurrentList.js
+++ b/lib/getCurrentList.js
@@ -1,7 +1,8 @@
-const isList = require('./isList');
+const getCurrentItem = require('./getCurrentItem');
+const getListForItem = require('./getListForItem');
 
 /**
- * Return the current list block, from current selection or from a node.
+ * Return the parent list block, from current selection or from a node (paragraph in a list item).
  *
  * @param {PluginOptions} opts
  * @param {Slate.State} state
@@ -9,21 +10,13 @@ const isList = require('./isList');
  * @return {Slate.Block || Void}
  */
 function getCurrentList(opts, state, block) {
-    const { document } = state;
+    const item = getCurrentItem(opts, state, block);
 
-    if (!block) {
-        if (!state.selection.startKey) return null;
-        block = state.startBlock;
+    if (!item) {
+        return null;
     }
 
-    if (isList(opts, block)) {
-        return block;
-    } else {
-        return document.getClosest(
-            block.key,
-            isList.bind(null, opts)
-        );
-    }
+    return getListForItem(opts, state, item);
 }
 
 module.exports = getCurrentList;

--- a/lib/getListForItem.js
+++ b/lib/getListForItem.js
@@ -1,0 +1,19 @@
+const isList = require('./isList');
+
+/**
+ * Return the parent list block for an item block.
+ *
+ * @param {PluginOptions} opts
+ * @param {Slate.State} state
+ * @param {Slate.Block} item
+ * @return {Slate.Block || Void}
+ */
+function getListForItem(opts, state, item) {
+    const { document } = state;
+    const parent = document.getParent(item.key);
+    return (parent && isList(opts, parent))
+        ? parent
+        : null;
+}
+
+module.exports = getListForItem;

--- a/lib/transforms/increaseItemDepth.js
+++ b/lib/transforms/increaseItemDepth.js
@@ -2,7 +2,7 @@ const Slate = require('slate');
 
 const getPreviousItem = require('../getPreviousItem');
 const getCurrentItem = require('../getCurrentItem');
-const getCurrentList = require('../getCurrentList');
+const getListForItem = require('../getListForItem');
 const isList = require('../isList');
 
 /**
@@ -52,7 +52,7 @@ function moveAsSubItem(opts, transform, item, destKey) {
             lastIndex
         );
     } else {
-        const currentList = getCurrentList(opts, transform.state, destination);
+        const currentList = getListForItem(opts, transform.state, destination);
 
         const newSublist = Slate.Block.create({
             kind: 'block',

--- a/tests/decrease-item-depth-basic/expected.yaml
+++ b/tests/decrease-item-depth-basic/expected.yaml
@@ -6,11 +6,17 @@ nodes:
       - kind: block
         type: list_item
         nodes:
-          - kind: text
-            text: First item
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: First item
 
       - kind: block
         type: list_item
         nodes:
-          - kind: text
-            text: Second item
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: Second item

--- a/tests/decrease-item-depth-basic/input.yaml
+++ b/tests/decrease-item-depth-basic/input.yaml
@@ -7,15 +7,21 @@ nodes:
       - kind: block
         type: list_item
         nodes:
-          - kind: text
-            text: First item
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: First item
 
           - kind: block
             type: ul_list
             nodes:
               - kind: block
                 type: list_item
-                key:  '_selection_key'
                 nodes:
-                  - kind: text
-                    text: Second item
+                  - kind: block
+                    type: paragraph
+                    key:  '_selection_key'
+                    nodes:
+                      - kind: text
+                        text: Second item

--- a/tests/decrease-item-depth-long-sublist/expected.yaml
+++ b/tests/decrease-item-depth-long-sublist/expected.yaml
@@ -6,14 +6,20 @@ nodes:
       - kind: block
         type: list_item
         nodes:
-          - kind: text
-            text: Item 1
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: Item 1
 
       - kind: block
         type: list_item
         nodes:
-          - kind: text
-            text: Item 1.1
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: Item 1.1
 
           - kind: block
             type: ul_list
@@ -21,5 +27,8 @@ nodes:
               - kind: block
                 type: list_item
                 nodes:
-                  - kind: text
-                    text: Item 1.2
+                  - kind: block
+                    type: paragraph
+                    nodes:
+                      - kind: text
+                        text: Item 1.2

--- a/tests/decrease-item-depth-long-sublist/input.yaml
+++ b/tests/decrease-item-depth-long-sublist/input.yaml
@@ -6,20 +6,29 @@ nodes:
       - kind: block
         type: list_item
         nodes:
-          - kind: text
-            text: Item 1
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: Item 1
 
           - kind: block
             type: ul_list
             nodes:
               - kind: block
                 type: list_item
-                key: '_selection_key'
                 nodes:
-                  - kind: text
-                    text: Item 1.1
+                  - kind: block
+                    type: paragraph
+                    key: '_selection_key'
+                    nodes:
+                      - kind: text
+                        text: Item 1.1
               - kind: block
                 type: list_item
                 nodes:
-                  - kind: text
-                    text: Item 1.2
+                  - kind: block
+                    type: paragraph
+                    nodes:
+                      - kind: text
+                        text: Item 1.2

--- a/tests/get-current-item/input.yaml
+++ b/tests/get-current-item/input.yaml
@@ -7,14 +7,20 @@ nodes:
         type: list_item
         key: 'previous_item'
         nodes:
-          - kind: text
-            ranges:
-              - text: First item
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                ranges:
+                  - text: First item
       - kind: block
         type: list_item
         key: 'current_item'
         nodes:
-          - kind: text
-            key: 'cursor'
-            ranges:
-              - text: Second item
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                key: 'cursor'
+                ranges:
+                  - text: Second item

--- a/tests/get-previous-item/input.yaml
+++ b/tests/get-previous-item/input.yaml
@@ -7,13 +7,20 @@ nodes:
         type: list_item
         key: 'previous_item'
         nodes:
-          - kind: text
-            ranges:
-              - text: First item
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                ranges:
+                  - text: First item
       - kind: block
         type: list_item
+        key: 'current_item'
         nodes:
-          - kind: text
-            key: 'current_item'
-            ranges:
-              - text: Second item
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                key: 'cursor'
+                ranges:
+                  - text: Second item

--- a/tests/increase-item-depth-basic/expected.yaml
+++ b/tests/increase-item-depth-basic/expected.yaml
@@ -7,8 +7,11 @@ nodes:
       - kind: block
         type: list_item
         nodes:
-          - kind: text
-            text: First item
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: First item
 
           - kind: block
             type: ul_list
@@ -16,5 +19,8 @@ nodes:
               - kind: block
                 type: list_item
                 nodes:
-                  - kind: text
-                    text: Second item
+                  - kind: block
+                    type: paragraph
+                    nodes:
+                      - kind: text
+                        text: Second item

--- a/tests/increase-item-depth-basic/input.yaml
+++ b/tests/increase-item-depth-basic/input.yaml
@@ -6,13 +6,19 @@ nodes:
       - kind: block
         type: list_item
         nodes:
-          - kind: text
-            text: First item
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: First item
 
       - kind: block
         type: list_item
         nodes:
-          - kind: text
+          - kind: block
+            type: paragraph
             key: '_selection_key'
-            ranges:
-              - text: Second item
+            nodes:
+              - kind: text
+                ranges:
+                  - text: Second item

--- a/tests/increase-item-depth-existing-sublist/expected.yaml
+++ b/tests/increase-item-depth-existing-sublist/expected.yaml
@@ -7,8 +7,11 @@ nodes:
       - kind: block
         type: list_item
         nodes:
-          - kind: text
-            text: Item 1
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: Item 1
 
           - kind: block
             type: ul_list
@@ -16,10 +19,16 @@ nodes:
               - kind: block
                 type: list_item
                 nodes:
-                  - kind: text
-                    text: Item 1.1
+                  - kind: block
+                    type: paragraph
+                    nodes:
+                      - kind: text
+                        text: Item 1.1
               - kind: block
                 type: list_item
                 nodes:
-                  - kind: text
-                    text: Item 2
+                  - kind: block
+                    type: paragraph
+                    nodes:
+                      - kind: text
+                        text: Item 2

--- a/tests/increase-item-depth-existing-sublist/input.yaml
+++ b/tests/increase-item-depth-existing-sublist/input.yaml
@@ -6,8 +6,11 @@ nodes:
       - kind: block
         type: list_item
         nodes:
-          - kind: text
-            text: Item 1
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: Item 1
           # Sub list
           - kind: block
             type: ul_list
@@ -15,13 +18,19 @@ nodes:
               - kind: block
                 type: list_item
                 nodes:
-                  - kind: text
-                    text: Item 1.1
+                  - kind: block
+                    type: paragraph
+                    nodes:
+                      - kind: text
+                        text: Item 1.1
 
       - kind: block
         type: list_item
         nodes:
-          - kind: text
+          - kind: block
+            type: paragraph
             key: '_selection_key'
-            ranges:
-              - text: Item 2
+            nodes:
+              - kind: text
+                ranges:
+                  - text: Item 2


### PR DESCRIPTION
This PR fixes the use of `slate-edit-list` with other block containers such as `slate-edit-blockquote`.