### PR TITLE
[Feature] Wrap in list with using data for node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Editors
+.idea
+
 # Logs
 logs
 *.log

--- a/example/state.yaml
+++ b/example/state.yaml
@@ -13,6 +13,9 @@ nodes:
     - text: This page is a basic example of Slate + slate-edit-list plugin. Press Enter in a list to create a new list item. Press Enter again to exit and Shift+Enter to create a paragraph in a list. The items at range are detected and highlighted, for demonstration purpose.
 - kind: block
   type: ul_list
+  data:
+    style:
+      listStyleType: disc
   nodes:
   - kind: block
     type: list_item
@@ -49,6 +52,9 @@ nodes:
         - text: 'Third item in the list, with a nested list'
     - kind: block
       type: ol_list
+      data:
+          style:
+            listStyleType: decimal
       nodes:
       - kind: block
         type: list_item

--- a/lib/transforms/decreaseItemDepth.js
+++ b/lib/transforms/decreaseItemDepth.js
@@ -39,7 +39,8 @@ function decreaseItemDepth(opts, transform, ordered) {
         // Add them as sublist of currentItem
         const sublist = Slate.Block.create({
             kind: 'block',
-            type: currentList.type
+            type: currentList.type,
+            data: currentList.data
         });
         // Add the sublist
         transform = transform.insertNodeByKey(

--- a/lib/transforms/increaseItemDepth.js
+++ b/lib/transforms/increaseItemDepth.js
@@ -56,7 +56,8 @@ function moveAsSubItem(opts, transform, item, destKey) {
 
         const newSublist = Slate.Block.create({
             kind: 'block',
-            type: currentList.type
+            type: currentList.type,
+            data: currentList.data
         });
 
         transform = transform.insertNodeByKey(

--- a/lib/transforms/wrapInList.js
+++ b/lib/transforms/wrapInList.js
@@ -1,3 +1,4 @@
+const Slate = require('slate');
 const { List } = require('immutable');
 const isList = require('../isList');
 
@@ -8,13 +9,17 @@ const isList = require('../isList');
  * @param  {PluginOptions} opts
  * @param  {Slate.Transform} transform
  * @param  {Boolean} ordered
+ * @param {Object|Data} [data]
  * @return {Transform} transform
  */
-function wrapInList(opts, transform, ordered) {
+function wrapInList(opts, transform, ordered, data) {
     const selectedBlocks = getHighestSelectedBlocks(transform.state);
 
     // Wrap in container
-    transform.wrapBlock(ordered ? opts.typeOL : opts.typeUL);
+    transform.wrapBlock({
+        type: ordered ? opts.typeOL : opts.typeUL,
+        data: Slate.Data.create(data)
+    });
 
     // Wrap in list items
     selectedBlocks.forEach((node) => {

--- a/tests/decrease-item-depth-long-sublist-with-data/expected.yaml
+++ b/tests/decrease-item-depth-long-sublist-with-data/expected.yaml
@@ -1,0 +1,37 @@
+
+nodes:
+  - kind: block
+    type: ul_list
+    nodes:
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: Item 1
+
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: Item 1.1
+
+          - kind: block
+            type: ul_list
+            data:
+              style:
+                listStyleType: 'square'
+            nodes:
+              - kind: block
+                type: list_item
+                nodes:
+                  - kind: block
+                    type: paragraph
+                    nodes:
+                      - kind: text
+                        text: Item 1.2

--- a/tests/decrease-item-depth-long-sublist-with-data/input.yaml
+++ b/tests/decrease-item-depth-long-sublist-with-data/input.yaml
@@ -1,0 +1,37 @@
+
+nodes:
+  - kind: block
+    type: ul_list
+    nodes:
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: Item 1
+
+          - kind: block
+            type: ul_list
+            data:
+              style:
+                listStyleType: 'square'
+            nodes:
+              - kind: block
+                type: list_item
+                nodes:
+                  - kind: block
+                    type: paragraph
+                    key: '_selection_key'
+                    nodes:
+                      - kind: text
+                        text: Item 1.1
+              - kind: block
+                type: list_item
+                nodes:
+                  - kind: block
+                    type: paragraph
+                    nodes:
+                      - kind: text
+                        text: Item 1.2

--- a/tests/decrease-item-depth-long-sublist-with-data/transform.js
+++ b/tests/decrease-item-depth-long-sublist-with-data/transform.js
@@ -1,0 +1,9 @@
+
+module.exports = function(plugin, state) {
+    const selectedBlock = state.document.getDescendant('_selection_key');
+    const transform = state.transform();
+    state = transform.moveToRangeOf(selectedBlock).moveForward(2).apply();
+
+    return plugin.transforms.decreaseItemDepth(state.transform())
+        .apply();
+};

--- a/tests/increase-item-depth-basic-with-data/expected.yaml
+++ b/tests/increase-item-depth-basic-with-data/expected.yaml
@@ -1,0 +1,32 @@
+
+
+nodes:
+  - kind: block
+    type: ul_list
+    data:
+      style:
+        listStyleType: 'disc'
+    nodes:
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: First item
+
+          - kind: block
+            type: ul_list
+            data:
+              style:
+                listStyleType: 'disc'
+            nodes:
+              - kind: block
+                type: list_item
+                nodes:
+                  - kind: block
+                    type: paragraph
+                    nodes:
+                      - kind: text
+                        text: Second item

--- a/tests/increase-item-depth-basic-with-data/input.yaml
+++ b/tests/increase-item-depth-basic-with-data/input.yaml
@@ -1,0 +1,27 @@
+
+nodes:
+  - kind: block
+    type: ul_list
+    data:
+      style:
+        listStyleType: 'disc'
+    nodes:
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: First item
+
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            key: '_selection_key'
+            nodes:
+              - kind: text
+                ranges:
+                  - text: Second item

--- a/tests/increase-item-depth-basic-with-data/transform.js
+++ b/tests/increase-item-depth-basic-with-data/transform.js
@@ -1,0 +1,9 @@
+
+module.exports = function(plugin, state) {
+    const selectedBlock = state.document.getDescendant('_selection_key');
+    const transform = state.transform();
+    state = transform.moveToRangeOf(selectedBlock).apply();
+
+    return plugin.transforms.increaseItemDepth(state.transform())
+        .apply();
+};

--- a/tests/wrap-in-list-list-with-data/expected.yaml
+++ b/tests/wrap-in-list-list-with-data/expected.yaml
@@ -1,0 +1,52 @@
+nodes:
+
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'Blah blah'
+
+  - kind: block
+    type: ul_list
+    data:
+      style:
+        listStyleType: 'disc'
+    nodes:
+
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: 'First item'
+          - kind: block
+            type: ul_list
+            nodes:
+              - kind: block
+                type: list_item
+                nodes:
+                  - kind: block
+                    type: paragraph
+                    nodes:
+                      - kind: text
+                        text: 'Subitem'
+
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: 'Second item'
+
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: 'Blah blah'

--- a/tests/wrap-in-list-list-with-data/input.yaml
+++ b/tests/wrap-in-list-list-with-data/input.yaml
@@ -1,0 +1,58 @@
+
+document:
+  nodes:
+
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'Blah blah'
+
+  - kind: block
+    type: ul_list
+    data:
+      style:
+        listStyleType: 'square'
+    nodes:
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                key: 'start'
+                text: 'First item'
+          - kind: block
+            type: ul_list
+            nodes:
+              - kind: block
+                type: list_item
+                nodes:
+                  - kind: block
+                    type: paragraph
+                    nodes:
+                      - kind: text
+                        text: 'Subitem'
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: 'Second item'
+
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        key: 'end'
+        text: 'Blah blah'
+
+selection:
+  anchorKey: 'start'
+  anchorOffset: 2
+  focusKey: 'end'
+  focusOffset: 4
+  isFocused: true

--- a/tests/wrap-in-list-list-with-data/transform.js
+++ b/tests/wrap-in-list-list-with-data/transform.js
@@ -1,0 +1,9 @@
+
+module.exports = function(plugin, state) {
+    const transform = state.transform();
+    const data = { style: { listStyleType: 'disc' } };
+    state = plugin.transforms.wrapInList(transform, false, data)
+        .apply();
+
+    return state;
+};

--- a/tests/wrap-in-list-multiple-with-data/expected.yaml
+++ b/tests/wrap-in-list-multiple-with-data/expected.yaml
@@ -1,0 +1,35 @@
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'Blah blah'
+
+  - kind: block
+    type: ul_list
+    data:
+      style:
+        listStyleType: 'disc'
+    nodes:
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: 'First item'
+      - kind: block
+        type: list_item
+        nodes:
+          - kind: block
+            type: paragraph
+            nodes:
+              - kind: text
+                text: 'Second item'
+
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'Blah blah'

--- a/tests/wrap-in-list-multiple-with-data/input.yaml
+++ b/tests/wrap-in-list-multiple-with-data/input.yaml
@@ -1,0 +1,36 @@
+
+document:
+  nodes:
+
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'Blah blah'
+
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        key: 'start'
+        text: 'First item'
+
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        key: 'end'
+        text: 'Second item'
+
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        text: 'Blah blah'
+
+selection:
+  anchorKey: 'start'
+  anchorOffset: 2
+  focusKey: 'end'
+  focusOffset: 4
+  isFocused: true

--- a/tests/wrap-in-list-multiple-with-data/transform.js
+++ b/tests/wrap-in-list-multiple-with-data/transform.js
@@ -1,0 +1,7 @@
+
+module.exports = function(plugin, state) {
+    const transform = state.transform();
+    const data = { style: { listStyleType: 'disc' } };
+    return plugin.transforms.wrapInList(transform, false, data)
+        .apply();
+};

--- a/tests/wrap-in-list-with-data/expected.yaml
+++ b/tests/wrap-in-list-with-data/expected.yaml
@@ -1,0 +1,16 @@
+
+nodes:
+    - kind: block
+      type: ol_list
+      data:
+        style:
+          listStyleType: decimal
+      nodes:
+          - kind: block
+            type: list_item
+            nodes:
+              - kind: block
+                type: paragraph
+                nodes:
+                  - kind: text
+                    text: Hello World

--- a/tests/wrap-in-list-with-data/input.yaml
+++ b/tests/wrap-in-list-with-data/input.yaml
@@ -1,0 +1,8 @@
+
+nodes:
+  - kind: block
+    type: paragraph
+    nodes:
+      - kind: text
+        ranges:
+          - text: Hello World

--- a/tests/wrap-in-list-with-data/transform.js
+++ b/tests/wrap-in-list-with-data/transform.js
@@ -1,0 +1,7 @@
+
+module.exports = function(plugin, state) {
+    const transform = state.transform();
+    const data = { style: { listStyleType: 'decimal' } };
+    return plugin.transforms.wrapInList(transform, true, data)
+        .apply();
+};


### PR DESCRIPTION
It would be cool to have possibility for creating different list's blocks with the same type.
Currently, plugin suggests the behavior, when we can identify 2 types of list, without different styling for them.
We suggest you decision for improving it. For example, an user of plugin can specify a `data`, when he creates the list. And he will use this `data` in schema for `Slate`.
Please, looks at the example of using:
```javascript
import React, { Component } from 'react';
import { Editor, Raw } from 'slate';
import EditList from 'slate-edit-list';

const UnorderedList = (props) => {
  const { attributes, node: { data }, children } = props;
  return <ul {...attributes} style={data.get('style')}>{children}</ul>
};

const OrderedList = (props) => {
  const { attributes, node: { data }, children } = props;
  return <ol {...attributes} style={data.get('style')}>{children}</ol>
};

const ListItem = (props) => {
  const { attributes, children } = props;
  return <li {...attributes}>{children}</li>
};

const slateSchema = {
  nodes: {
    'unordered-list': UnorderedList,
    'ordered-list': OrderedList,
    'list-item': ListItem
  }
};

const editListPlugin = EditList({
  typeUL: 'unordered-list',
  typeOL: 'ordered-list',
  typeItem: 'list-item',
});

const slatePlugins = [
  editListPlugin
];

export default class SlateEditor extends Component {
  constructor() {
    super();
    this.state = {
      editorState: Raw.deserialize({
        nodes: [
          {
            kind: 'block',
            type: 'paragraph',
          },
        ],
      }, { terse: true })
    }
  }

  applyListType(listStyleType) {
    const transform = this.state.editorState.transform();
    const editorState = editListPlugin.transforms.wrapInList(
      transform,
      listStyleType === 'decimal',
      { style: { listStyleType } }
    ).apply();
    this.setState({
      editorState
    })
  }


  handleChange(editorState) {
    this.setState({
      editorState
    })
  }

  render() {
    return <div>
      {
        ['decimal', 'square', 'disc'].map((listType) => <button onClick={() => this.applyListType(listType)}>{`Create ${listType} list`}</button>)
      }
      <Editor
        state={this.state.editorState}
        schema={slateSchema}
        plugins={slatePlugins}
        onChange={(editorState) => this.handleChange(editorState)}
      />
    </div>
  }
}
```
Please, look at the pull request. You can find the more useful example in it.