### PR TITLE
Support more than two list types

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,7 @@ const plugins = [
 
 This plugin accepts options to redefine the following block types:
 
-- `<String> typeUL="ul_list"` — type for bulleted lists.
-- `<String> typeOL="ol_list"` — type for numbered lists.
+- `<String> types={["ol_list", "ul_list"]}` — an array of types that should be considered as lists
 - `<String> typeItem="list_item"` — type for list items.
 - `<String> typeDefault="paragraph"` — type for default block in list items.
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ const plugins = [
 
 This plugin accepts options to redefine the following block types:
 
-- `<String> types={["ol_list", "ul_list"]}` — an array of types that should be considered as lists
+- `<String> types={["ol_list", "ul_list"]}` — the array of possible types for list containers. First value will be used as default.
 - `<String> typeItem="list_item"` — type for list items.
 - `<String> typeDefault="paragraph"` — type for default block in list items.
 
@@ -162,9 +162,9 @@ Decrease the depth of the current item.
 
 #### `transforms.wrapInList`
 
-`plugin.transforms.wrapInList(transform: Transform, ordered: Boolean?, data: Object|Data?) => Transform`
+`plugin.transforms.wrapInList(transform: Transform, type: String?, data: Object|Data?) => Transform`
 
-Wrap the current blocks in list items. You can pass optional data for the created list container.
+Wrap the current blocks in list items of a list container of the given type. You can pass optional data for the created list container.
 
 #### `transforms.unwrapList`
 

--- a/lib/isList.js
+++ b/lib/isList.js
@@ -4,9 +4,7 @@
  * @return {Boolean} true if the node is a UL or OL
  */
 function isList(opts, node) {
-    return node.type === opts.typeUL
-        || node.type === opts.typeOL
-        || opts.types.includes(node.type);
+    return opts.types.includes(node.type);
 }
 
 module.exports = isList;

--- a/lib/isList.js
+++ b/lib/isList.js
@@ -5,7 +5,8 @@
  */
 function isList(opts, node) {
     return node.type === opts.typeUL
-        || node.type === opts.typeOL;
+        || node.type === opts.typeOL
+        || opts.types.includes(node.type);
 }
 
 module.exports = isList;

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -67,7 +67,7 @@ function listsContainOnlyItems(opts) {
  * of a list block.
  */
 function itemsDescendList(opts) {
-    const isList = matchTypes([opts.typeUL, opts.typeOL]);
+    const isList = matchTypes([opts.typeUL, opts.typeOL].concat(opts.types));
 
     return {
         match(node) {

--- a/lib/makeSchema.js
+++ b/lib/makeSchema.js
@@ -1,12 +1,8 @@
-const Immutable = require('immutable');
-const { Set } = Immutable;
+const isList = require('./isList');
 
 /**
  * Create a schema for lists
- * @param {String} opts.typeUL The type of unordered lists
- * @param {String} opts.typeOL The type of ordered lists
- * @param {String} opts.typeItem The type of list items
- * @param {String} opts.typeDefault The type of the default block in list items
+ * @param {PluginOptions} The plugin options
  * @return {Object} A schema definition with rules to normalize lists
  */
 function makeSchema(opts) {
@@ -21,17 +17,13 @@ function makeSchema(opts) {
 }
 
 /**
- * @param {String} opts.typeUL The type of unordered lists
- * @param {String} opts.typeOL The type of ordered lists
- * @param {String} opts.typeItem The type of list items
+ * @param {PluginOptions} The plugin options
  * @return {Object} A rule that ensure lists only contain list
  * items, and at least one.
  */
 function listsContainOnlyItems(opts) {
-    const isList = matchTypes([opts.typeUL, opts.typeOL]);
-
     return {
-        match: isList,
+        match: (node) => isList(opts, node),
 
         validate(list) {
             const notItems = list.nodes.filter(n => n.type !== opts.typeItem);
@@ -60,19 +52,15 @@ function listsContainOnlyItems(opts) {
 }
 
 /**
- * @param {String} opts.typeUL The type of unordered lists
- * @param {String} opts.typeOL The type of ordered lists
- * @param {String} opts.typeItem The type of list items
+ * @param {PluginOptions} The plugin options
  * @return {Object} A rule that ensure list items are always children
  * of a list block.
  */
 function itemsDescendList(opts) {
-    const isList = matchTypes([opts.typeUL, opts.typeOL].concat(opts.types));
-
     return {
         match(node) {
             return (node.kind === 'block' || node.kind === 'document')
-                && !isList(node);
+                && !isList(opts, node);
         },
 
         validate(block) {
@@ -103,16 +91,13 @@ function itemsDescendList(opts) {
 }
 
 /**
- * @param {String} opts.typeItem The type of list items
- * @param {String} opts.typeDefault The type of the default block in list items
+ * @param {PluginOptions} The plugin options
  * @return {Object} A rule that ensure list items always contain
  * blocks.
  */
 function itemsContainBlocks(opts) {
-    const isItem = matchTypes([opts.typeItem]);
-
     return {
-        match: isItem,
+        match: (node) => node.type === opts.typeItem,
 
         validate(item) {
             const shouldWrap = item.nodes.some(node => node.kind !== 'block');
@@ -139,17 +124,6 @@ function itemsContainBlocks(opts) {
             );
         }
     };
-}
-
-/**
- * @param {Array<String>} types
- * @return {Function} A function that returns true for nodes that
- * match one of the given types.
- */
-function matchTypes(types) {
-    types = new Set(types);
-
-    return (node) => types.some(type => type === node.type);
 }
 
 module.exports = makeSchema;

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,11 +1,8 @@
 const { Record } = require('immutable');
 
 const DEFAULTS = {
-    types: [],
-    // The type of the lists
-    typeUL: 'ul_list',
-    // The type of ordered lists
-    typeOL: 'ol_list',
+    // The possibles types for list containers
+    types: ['ul_list', 'ol_list'],
     // The type of list items
     typeItem: 'list_item',
     // The type of default block in items

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,6 +1,7 @@
 const { Record } = require('immutable');
 
 const DEFAULTS = {
+    types: [],
     // The type of the lists
     typeUL: 'ul_list',
     // The type of ordered lists

--- a/lib/transforms/wrapInList.js
+++ b/lib/transforms/wrapInList.js
@@ -8,16 +8,23 @@ const isList = require('../isList');
  *
  * @param  {PluginOptions} opts
  * @param  {Slate.Transform} transform
- * @param  {Boolean} [ordered=false]
+ * @param  {Boolean|String} type
  * @param  {Object|Data} [data]
  * @return {Transform} transform
  */
 function wrapInList(opts, transform, ordered, data) {
     const selectedBlocks = getHighestSelectedBlocks(transform.state);
+    let type;
+
+    if (typeof ordered === 'string') {
+        type = ordered;
+    } else {
+        type = ordered ? opts.typeOL : opts.typeUL;
+    }
 
     // Wrap in container
     transform.wrapBlock({
-        type: ordered ? opts.typeOL : opts.typeUL,
+        type,
         data: Slate.Data.create(data)
     });
 

--- a/lib/transforms/wrapInList.js
+++ b/lib/transforms/wrapInList.js
@@ -8,19 +8,13 @@ const isList = require('../isList');
  *
  * @param  {PluginOptions} opts
  * @param  {Slate.Transform} transform
- * @param  {Boolean|String} type
- * @param  {Object|Data} [data]
+ * @param  {String?} type
+ * @param  {Object|Data?} [data]
  * @return {Transform} transform
  */
 function wrapInList(opts, transform, ordered, data) {
     const selectedBlocks = getHighestSelectedBlocks(transform.state);
-    let type;
-
-    if (typeof ordered === 'string') {
-        type = ordered;
-    } else {
-        type = ordered ? opts.typeOL : opts.typeUL;
-    }
+    const type = ordered || opts.types[0];
 
     // Wrap in container
     transform.wrapBlock({

--- a/tests/wrap-in-list-with-data/transform.js
+++ b/tests/wrap-in-list-with-data/transform.js
@@ -2,6 +2,6 @@
 module.exports = function(plugin, state) {
     const transform = state.transform();
     const data = { style: { listStyleType: 'decimal' } };
-    return plugin.transforms.wrapInList(transform, true, data)
+    return plugin.transforms.wrapInList(transform, 'ol_list', data)
         .apply();
 };

--- a/tests/wrap-in-ol/transform.js
+++ b/tests/wrap-in-ol/transform.js
@@ -1,6 +1,6 @@
 
 module.exports = function(plugin, state) {
     const transform = state.transform();
-    return plugin.transforms.wrapInList(transform, true)
+    return plugin.transforms.wrapInList(transform, 'ol_list')
         .apply();
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1225,13 +1225,13 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug@2.2.0, debug@^2.1.1, debug@^2.2.0, debug@~2.2.0:
+debug@2.2.0, debug@^2.1.1, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
     ms "0.7.1"
 
-debug@^2.3.2:
+debug@^2.2.0, debug@^2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.3.3.tgz#40c453e67e6e13c901ddec317af8986cda9eff8c"
   dependencies:


### PR DESCRIPTION
I needed the functionality to be able to have more than two list types, this PR enables that whilst maintaining backwards compatibility with the previous two parameters, `type_UL` and `type_OL`.

Because the code needs to be transpiled it's actually kind of a pain to use a forked version of the lib. Hoping I can make this PR acceptable for merging, let me know thoughts or anything you'd like to see changed! 

