### PR TITLE
use slate/lib for importing Slate components

### DIFF
--- a/lib/transforms/decreaseItemDepth.js
+++ b/lib/transforms/decreaseItemDepth.js
@@ -1,4 +1,4 @@
-const Slate = require('slate');
+const Block = require('slate/lib/models/block').default;
 const getItemDepth = require('../getItemDepth');
 const getCurrentItem = require('../getCurrentItem');
 
@@ -37,7 +37,7 @@ function decreaseItemDepth(opts, transform, ordered) {
 
     if (!followingItems.isEmpty()) {
         // Add them as sublist of currentItem
-        const sublist = Slate.Block.create({
+        const sublist = Block.create({
             kind: 'block',
             type: currentList.type,
             data: currentList.data

--- a/lib/transforms/increaseItemDepth.js
+++ b/lib/transforms/increaseItemDepth.js
@@ -1,4 +1,4 @@
-const Slate = require('slate');
+const Block = require('slate/lib/models/block').default;
 
 const getPreviousItem = require('../getPreviousItem');
 const getCurrentItem = require('../getCurrentItem');
@@ -54,7 +54,7 @@ function moveAsSubItem(opts, transform, item, destKey) {
     } else {
         const currentList = getListForItem(opts, transform.state, destination);
 
-        const newSublist = Slate.Block.create({
+        const newSublist = Block.create({
             kind: 'block',
             type: currentList.type,
             data: currentList.data

--- a/lib/transforms/wrapInList.js
+++ b/lib/transforms/wrapInList.js
@@ -1,4 +1,4 @@
-const Slate = require('slate');
+const Data = require('slate/lib/models/data').default;
 const { List } = require('immutable');
 const isList = require('../isList');
 
@@ -19,7 +19,7 @@ function wrapInList(opts, transform, ordered, data) {
     // Wrap in container
     transform.wrapBlock({
         type,
-        data: Slate.Data.create(data)
+        data: Data.create(data)
     });
 
     // Wrap in list items


### PR DESCRIPTION
Using module relative imports helps reduce the size of packages when bundling with webpack, browserify etc

I ran a quick test comparing the bundle in example

```text
2.3M	example/bundle.js
1.4M	example/bundle.new.js
```