### PR TITLE
Add a prepare task

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "stringify": "^5.1.0"
   },
   "scripts": {
+    "prepare": "babel ./lib --out-dir ./dist",
     "prepublish": "babel ./lib --out-dir ./dist",
     "postpublish": "npm run deploy-example",
     "lint": "eslint ./",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   },
   "scripts": {
     "prepare": "babel ./lib --out-dir ./dist",
-    "prepublish": "babel ./lib --out-dir ./dist",
     "postpublish": "npm run deploy-example",
     "lint": "eslint ./",
     "build-example": "browserify ./example/main.js -o ./example/bundle.js -t [ babelify --presets [ es2015 react ] ] -t [ stringify --extensions [.yaml] ]",


### PR DESCRIPTION
In newer versions of yarn and npm, referencing a dependency in a git repo will run the `prepare` task before installing the dependency. This way, we can use the git repo as if it's a fully published package.