### PR TITLE
Update to Slate 0.27.4

### DIFF
--- a/example/main.js
+++ b/example/main.js
@@ -38,24 +38,24 @@ const SCHEMA = {
     }
 };
 
-const Example = React.createClass({
-    getInitialState() {
-        return {
-            state: Slate.State.fromJSON(stateJson)
-        };
-    },
+class Example extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { state: Slate.State.fromJSON(stateJson) };
+        this.onChange = this.onChange.bind(this);
+    }
 
     onChange({ state }) {
         this.setState({
             state
         });
-    },
+    }
 
     call(change) {
         this.setState({
             state: this.state.state.change().call(change).state
         });
-    },
+    }
 
     renderToolbar() {
         const { wrapInList, unwrapList, increaseItemDepth, decreaseItemDepth } = plugin.changes;
@@ -84,7 +84,7 @@ const Example = React.createClass({
                 <button onClick={() => this.call(unwrapList)}>Unwrap from list</button>
             </div>
         );
-    },
+    }
 
     render() {
         return (
@@ -98,7 +98,7 @@ const Example = React.createClass({
             </div>
         );
     }
-});
+}
 
 ReactDOM.render(
     <Example />,

--- a/example/state.yaml
+++ b/example/state.yaml
@@ -4,13 +4,13 @@ document:
       type: heading
       nodes:
       - kind: text
-        ranges:
+        leaves:
         - text: 'Slate + List Edition'
     - kind: block
       type: paragraph
       nodes:
       - kind: text
-        ranges:
+        leaves:
         - text: This page is a basic example of Slate + slate-edit-list plugin. Press Enter in a list to create a new list item. Press Enter again to exit and Shift+Enter to create a paragraph in a list. The items at range are detected and highlighted, for demonstration purpose.
     - kind: block
       type: ul_list
@@ -25,7 +25,7 @@ document:
           type: paragraph
           nodes:
           - kind: text
-            ranges:
+            leaves:
             - text: 'First item in the list'
       - kind: block
         type: list_item
@@ -34,13 +34,13 @@ document:
           type: heading
           nodes:
           - kind: text
-            ranges:
+            leaves:
             - text: 'With blocks:'
         - kind: block
           type: paragraph
           nodes:
           - kind: text
-            ranges:
+            leaves:
             - text: 'List item can contain blocks'
       - kind: block
         type: list_item
@@ -49,7 +49,7 @@ document:
           type: paragraph
           nodes:
           - kind: text
-            ranges:
+            leaves:
             - text: 'Third item in the list, with a nested list'
         - kind: block
           type: ol_list
@@ -64,7 +64,7 @@ document:
               type: paragraph
               nodes:
               - kind: text
-                ranges:
+                leaves:
                 - text: 'First item in the nested list'
           - kind: block
             type: list_item
@@ -73,11 +73,11 @@ document:
               type: paragraph
               nodes:
               - kind: text
-                ranges:
+                leaves:
                 - text: 'Second item in the nested list'
     - kind: block
       type: paragraph
       nodes:
       - kind: text
-        ranges:
+        leaves:
         - text: 'End paragraph'

--- a/lib/changes/decreaseItemDepth.js
+++ b/lib/changes/decreaseItemDepth.js
@@ -49,11 +49,8 @@ function decreaseItemDepth(opts, change, ordered) {
         );
 
         change.moveNodeByKey(
-          currentItem.key, parentList.key, parentList.nodes.indexOf(parentItem) + 1
+          currentItem.key, parentList.key, parentList.nodes.indexOf(parentItem) + 1, { normalize: false }
         );
-
-        // Creating a block now adds a text node.  Lets get rid of it.
-        const extraEmptyText = sublist.nodes.get(0);
 
         // Move the followingItems to the sublist
         followingItems.forEach((item, index) => change.moveNodeByKey(
@@ -62,8 +59,6 @@ function decreaseItemDepth(opts, change, ordered) {
           sublist.nodes.size + index,
           { normalize: false }
         ));
-
-        change.removeNodeByKey(extraEmptyText.key);
     } else {
         change.moveNodeByKey(
           currentItem.key, parentList.key, parentList.nodes.indexOf(parentItem) + 1

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,9 +18,9 @@ const getCurrentList    = require('./getCurrentList');
 const getItemsAtRange   = require('./getItemsAtRange');
 const getPreviousItem   = require('./getPreviousItem');
 
-const KEY_ENTER     = 'enter';
-const KEY_TAB       = 'tab';
-const KEY_BACKSPACE = 'backspace';
+const KEY_ENTER     = 'Enter';
+const KEY_TAB       = 'Tab';
+const KEY_BACKSPACE = 'Backspace';
 
 /**
  * A Slate plugin to handle keyboard events in lists.
@@ -49,11 +49,10 @@ function EditList(opts = {}) {
     /**
      * User is pressing a key in the editor
      */
-    function onKeyDown(e, data, change) {
-        // Build arguments list
-        const args = [e, data, change, opts];
+    function onKeyDown(event, change, editor) {
+        const args = [event, change, editor, opts]
 
-        switch (data.key) {
+        switch (event.key) {
         case KEY_ENTER:
             return onEnter(...args);
         case KEY_TAB:

--- a/lib/onBackspace.js
+++ b/lib/onBackspace.js
@@ -4,7 +4,7 @@ const getCurrentItem = require('./getCurrentItem');
 /**
  * User pressed Delete in an editor
  */
-function onBackspace(event, data, change, opts) {
+function onBackspace(event, change, editor, opts) {
     const { state } = change;
     const { startOffset, selection } = state;
 

--- a/lib/onEnter.js
+++ b/lib/onEnter.js
@@ -11,10 +11,10 @@ const getItemDepth = require('./getItemDepth');
  * Enter in an empty list item should remove it
  * Shift+Enter in a list item should make a new line
  */
-function onEnter(event, data, change, opts) {
+function onEnter(event, change, editor, opts) {
     // Pressing Shift+Enter
     // should split block normally
-    if (data.isShift) {
+    if (event.shiftKey) {
         return null;
     }
 

--- a/lib/onTab.js
+++ b/lib/onTab.js
@@ -7,7 +7,7 @@ const getCurrentItem = require('./getCurrentItem');
  * Tab       -> Increase item depth if inside a list item
  * Shift+Tab -> Decrease item depth if inside a list item
  */
-function onTab(event, data, change, opts) {
+function onTab(event, change, editor, opts) {
     const { state } = change;
     const { isCollapsed } = state;
 
@@ -16,7 +16,7 @@ function onTab(event, data, change, opts) {
     }
 
     // Shift+tab reduce depth
-    if (data.isShift) {
+    if (event.shiftKey) {
         event.preventDefault();
 
         return decreaseItemDepth(

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "repository": "git://github.com/GitbookIO/slate-edit-list.git",
   "main": "./dist/index.js",
   "peerDependencies": {
-    "slate": "^0.23.0"
+    "slate": "^0.27.4"
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",
@@ -20,12 +20,13 @@
     "expect": "^1.20.2",
     "gh-pages": "^0.11.0",
     "http-server": "^0.9.0",
+    "immutable": "^3.8.2",
     "mocha": "^3.0.1",
-    "react": "^15.3.0",
-    "react-dom": "^15.3.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "read-metadata": "^1.0.0",
-    "slate": "^0.24.0",
-    "slate-react": "^0.1.5",
+    "slate": "^0.27.4",
+    "slate-react": "^0.7.2",
     "stringify": "^5.1.0"
   },
   "scripts": {

--- a/tests/backspace-empty-between-inline/change.js
+++ b/tests/backspace-empty-between-inline/change.js
@@ -8,10 +8,11 @@ module.exports = function(plugin, change) {
     plugin.onKeyDown(
         {
             preventDefault: () => {},
-            stopPropagation: () => {}
+            stopPropagation: () => {},
+            key: 'Backspace'
         },
-        { key: 'backspace' },
-        change
+        change,
+        {}
     );
 
     // Selection check

--- a/tests/backspace-empty-between-inline/expected.yaml
+++ b/tests/backspace-empty-between-inline/expected.yaml
@@ -10,22 +10,22 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
                 - kind: inline
                   type: link
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "First item"
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
     - kind: block
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: ""
     - kind: block
       type: ul_list
@@ -37,14 +37,14 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
                 - kind: inline
                   type: link
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "Third item"
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""

--- a/tests/backspace-empty-between-inline/input.yaml
+++ b/tests/backspace-empty-between-inline/input.yaml
@@ -11,16 +11,16 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
                 - kind: inline
                   type: link
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "First item"
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
         - kind: block
           type: list_item
@@ -30,7 +30,7 @@ document:
               nodes:
                 - kind: text
                   key: '_selection_key'
-                  ranges:
+                  leaves:
                     - text: ""
         - kind: block
           type: list_item
@@ -39,14 +39,14 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
                 - kind: inline
                   type: link
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "Third item"
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""

--- a/tests/backspace-end-of-inline/change.js
+++ b/tests/backspace-end-of-inline/change.js
@@ -6,10 +6,11 @@ module.exports = function(plugin, change) {
     plugin.onKeyDown(
         {
             preventDefault: () => {},
-            stopPropagation: () => {}
+            stopPropagation: () => {},
+            key: 'Backspace'
         },
-        { key: 'backspace' },
-        change
+        change,
+        {}
     );
 
     return change;

--- a/tests/backspace-end-of-inline/expected.yaml
+++ b/tests/backspace-end-of-inline/expected.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
 
         - kind: block
@@ -20,16 +20,16 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
                 - kind: inline
                   type: link
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "Second item"
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
         - kind: block
           type: list_item
@@ -38,14 +38,14 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
                 - kind: inline
                   type: link
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "Third item"
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""

--- a/tests/backspace-end-of-inline/input.yaml
+++ b/tests/backspace-end-of-inline/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
 
         - kind: block
@@ -20,17 +20,17 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
                 - kind: inline
                   type: link
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "Second item"
                 - kind: text
                   key: '_selection_key'
-                  ranges:
+                  leaves:
                     - text: ""
         - kind: block
           type: list_item
@@ -39,14 +39,14 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
                 - kind: inline
                   type: link
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "Third item"
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""

--- a/tests/backspace-start-of-inline/change.js
+++ b/tests/backspace-start-of-inline/change.js
@@ -8,10 +8,11 @@ module.exports = function(plugin, change) {
     plugin.onKeyDown(
         {
             preventDefault: () => {},
-            stopPropagation: () => {}
+            stopPropagation: () => {},
+            key: 'Backspace'
         },
-        { key: 'backspace' },
-        change
+        change,
+        {}
     );
 
     // Selection check

--- a/tests/backspace-start-of-inline/expected.yaml
+++ b/tests/backspace-start-of-inline/expected.yaml
@@ -10,22 +10,22 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
     - kind: block
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: ""
         - kind: inline
           type: link
           nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "Second item" # |Second item
         - kind: text
-          ranges:
+          leaves:
             - text: ""
     - kind: block
       type: ul_list
@@ -37,14 +37,14 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
                 - kind: inline
                   type: link
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "Third item"
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""

--- a/tests/backspace-start-of-inline/input.yaml
+++ b/tests/backspace-start-of-inline/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
 
         - kind: block
@@ -21,16 +21,16 @@ document:
               nodes:
                 - kind: text
                   key: '_selection_key'
-                  ranges:
+                  leaves:
                     - text: ""
                 - kind: inline
                   type: link
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "Second item"
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
         - kind: block
           type: list_item
@@ -39,14 +39,14 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
                 - kind: inline
                   type: link
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "Third item"
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""

--- a/tests/backspace-start-of-item/change.js
+++ b/tests/backspace-start-of-item/change.js
@@ -7,9 +7,10 @@ module.exports = function(plugin, change) {
     return plugin.onKeyDown(
         {
             preventDefault: () => {},
-            stopPropagation: () => {}
+            stopPropagation: () => {},
+            key: 'Backspace'
         },
-        { key: 'backspace' },
-        change
+        change,
+        {}
     );
 };

--- a/tests/backspace-start-of-item/expected.yaml
+++ b/tests/backspace-start-of-item/expected.yaml
@@ -10,11 +10,11 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
     - kind: block
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: Second item

--- a/tests/backspace-start-of-item/input.yaml
+++ b/tests/backspace-start-of-item/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
 
         - kind: block
@@ -21,5 +21,5 @@ document:
               nodes:
                 - kind: text
                   key: '_selection_key'
-                  ranges:
+                  leaves:
                     - text: Second item # |Second Item

--- a/tests/decrease-item-depth-basic/expected.yaml
+++ b/tests/decrease-item-depth-basic/expected.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
 
         - kind: block
@@ -20,5 +20,5 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Second item

--- a/tests/decrease-item-depth-basic/input.yaml
+++ b/tests/decrease-item-depth-basic/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
 
             - kind: block
@@ -24,5 +24,5 @@ document:
                       key:  '_selection_key'
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Second item

--- a/tests/decrease-item-depth-long-sublist-with-data/expected.yaml
+++ b/tests/decrease-item-depth-long-sublist-with-data/expected.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1
 
         - kind: block
@@ -20,7 +20,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1.1
 
             - kind: block
@@ -36,5 +36,5 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.2

--- a/tests/decrease-item-depth-long-sublist-with-data/input.yaml
+++ b/tests/decrease-item-depth-long-sublist-with-data/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1
 
             - kind: block
@@ -27,7 +27,7 @@ document:
                       key: '_selection_key'
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.1
                 - kind: block
                   type: list_item
@@ -36,5 +36,5 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.2

--- a/tests/decrease-item-depth-long-sublist/expected.yaml
+++ b/tests/decrease-item-depth-long-sublist/expected.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1
 
         - kind: block
@@ -20,7 +20,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1.1
 
             - kind: block
@@ -33,5 +33,5 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.2

--- a/tests/decrease-item-depth-long-sublist/input.yaml
+++ b/tests/decrease-item-depth-long-sublist/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1
 
             - kind: block
@@ -24,7 +24,7 @@ document:
                       key: '_selection_key'
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.1
                 - kind: block
                   type: list_item
@@ -33,5 +33,5 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.2

--- a/tests/enter-empty-block-in-item/change.js
+++ b/tests/enter-empty-block-in-item/change.js
@@ -3,9 +3,10 @@ module.exports = function(plugin, change) {
     return plugin.onKeyDown(
         {
             preventDefault: () => {},
-            stopPropagation: () => {}
+            stopPropagation: () => {},
+            key: 'Enter'
         },
-        { key: 'enter' },
-        change
+        change,
+        {}
     );
 };

--- a/tests/enter-empty-block-in-item/expected.yaml
+++ b/tests/enter-empty-block-in-item/expected.yaml
@@ -10,7 +10,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'First item'
     - kind: block
       type: list_item
@@ -19,13 +19,13 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'A first paragraph'
       - kind: block
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: ''
     - kind: block
       type: list_item
@@ -34,5 +34,5 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: ''

--- a/tests/enter-empty-block-in-item/input.yaml
+++ b/tests/enter-empty-block-in-item/input.yaml
@@ -11,7 +11,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'First item'
 
     - kind: block
@@ -21,14 +21,14 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'A first paragraph'
       - kind: block
         type: paragraph
         nodes:
         - kind: text
           key: 'start'
-          ranges:
+          leaves:
             - text: ''
 
 selection:

--- a/tests/enter-empty-item/change.js
+++ b/tests/enter-empty-item/change.js
@@ -3,9 +3,10 @@ module.exports = function(plugin, change) {
     return plugin.onKeyDown(
         {
             preventDefault: () => {},
-            stopPropagation: () => {}
+            stopPropagation: () => {},
+            key: 'Enter'
         },
-        { key: 'enter' },
-        change
+        change,
+        {}
     );
 };

--- a/tests/enter-empty-item/expected.yaml
+++ b/tests/enter-empty-item/expected.yaml
@@ -10,12 +10,12 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'First item'
 
   - kind: block
     type: paragraph
     nodes:
     - kind: text
-      ranges:
+      leaves:
         - text: ''

--- a/tests/enter-empty-item/input.yaml
+++ b/tests/enter-empty-item/input.yaml
@@ -11,7 +11,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'First item'
 
     - kind: block
@@ -22,7 +22,7 @@ document:
         nodes:
         - kind: text
           key: 'start'
-          ranges:
+          leaves:
             - text: ''
 
 selection:

--- a/tests/enter-middle-item/change.js
+++ b/tests/enter-middle-item/change.js
@@ -3,9 +3,10 @@ module.exports = function(plugin, change) {
     return plugin.onKeyDown(
         {
             preventDefault: () => {},
-            stopPropagation: () => {}
+            stopPropagation: () => {},
+            key: 'Enter'
         },
-        { key: 'enter' },
-        change
+        change,
+        {}
     );
 };

--- a/tests/enter-middle-item/expected.yaml
+++ b/tests/enter-middle-item/expected.yaml
@@ -10,7 +10,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'First item'
 
     - kind: block
@@ -20,7 +20,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'Second'
 
     - kind: block
@@ -30,5 +30,5 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: ' item'

--- a/tests/enter-middle-item/input.yaml
+++ b/tests/enter-middle-item/input.yaml
@@ -10,7 +10,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'First item'
 
     - kind: block
@@ -21,7 +21,7 @@ document:
         nodes:
         - kind: text
           key: 'start'
-          ranges:
+          leaves:
             - text: 'Second item'
 
 selection:

--- a/tests/enter-nested-item/change.js
+++ b/tests/enter-nested-item/change.js
@@ -3,9 +3,10 @@ module.exports = function(plugin, change) {
     return plugin.onKeyDown(
         {
             preventDefault: () => {},
-            stopPropagation: () => {}
+            stopPropagation: () => {},
+            key: 'Enter'
         },
-        { key: 'enter' },
-        change
+        change,
+        {}
     );
 };

--- a/tests/enter-nested-item/expected.yaml
+++ b/tests/enter-nested-item/expected.yaml
@@ -10,7 +10,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'First item'
 
     - kind: block
@@ -20,7 +20,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'Second item'
 
     - kind: block
@@ -30,5 +30,5 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: ''

--- a/tests/enter-nested-item/input.yaml
+++ b/tests/enter-nested-item/input.yaml
@@ -11,7 +11,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'First item'
 
     - kind: block
@@ -21,7 +21,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'Second item'
       - kind: block
         type: ul_list
@@ -34,7 +34,7 @@ document:
             nodes:
             - kind: text
               key: 'start'
-              ranges:
+              leaves:
                 - text: ''
 
 selection:

--- a/tests/get-current-item/input.yaml
+++ b/tests/get-current-item/input.yaml
@@ -11,7 +11,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
         - kind: block
           type: list_item
@@ -22,5 +22,5 @@ document:
               nodes:
                 - kind: text
                   key: 'cursor'
-                  ranges:
+                  leaves:
                     - text: Second item

--- a/tests/get-previous-item/input.yaml
+++ b/tests/get-previous-item/input.yaml
@@ -11,7 +11,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
         - kind: block
           type: list_item
@@ -22,5 +22,5 @@ document:
               nodes:
                 - kind: text
                   key: 'cursor'
-                  ranges:
+                  leaves:
                   - text: Second item

--- a/tests/increase-item-depth-basic-with-data/expected.yaml
+++ b/tests/increase-item-depth-basic-with-data/expected.yaml
@@ -13,7 +13,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
 
             - kind: block
@@ -29,5 +29,5 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Second item

--- a/tests/increase-item-depth-basic-with-data/input.yaml
+++ b/tests/increase-item-depth-basic-with-data/input.yaml
@@ -13,7 +13,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
 
         - kind: block
@@ -24,5 +24,5 @@ document:
               key: '_selection_key'
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Second item

--- a/tests/increase-item-depth-basic/expected.yaml
+++ b/tests/increase-item-depth-basic/expected.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
 
             - kind: block
@@ -23,5 +23,5 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Second item

--- a/tests/increase-item-depth-basic/input.yaml
+++ b/tests/increase-item-depth-basic/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
 
         - kind: block
@@ -21,5 +21,5 @@ document:
               key: '_selection_key'
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Second item

--- a/tests/increase-item-depth-complex/expected.yaml
+++ b/tests/increase-item-depth-complex/expected.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
         - kind: block
           type: list_item
@@ -19,7 +19,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Second item
             - kind: block
               type: ol_list
@@ -31,7 +31,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: First item in the nested list
                     - kind: block
                       type: ol_list
@@ -43,5 +43,5 @@ document:
                               type: paragraph
                               nodes:
                                 - kind: text
-                                  ranges:
+                                  leaves:
                                     - text: Second item in the nested list

--- a/tests/increase-item-depth-complex/input.yaml
+++ b/tests/increase-item-depth-complex/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
         - kind: block
           type: list_item
@@ -19,7 +19,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Second item
             - kind: block
               type: ol_list
@@ -31,7 +31,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: First item in the nested list
                 - kind: block
                   type: list_item
@@ -41,5 +41,5 @@ document:
                       key: '_selection_key'
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Second item in the nested list

--- a/tests/increase-item-depth-existing-sublist/expected.yaml
+++ b/tests/increase-item-depth-existing-sublist/expected.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1
 
             - kind: block
@@ -23,7 +23,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.1
                 - kind: block
                   type: list_item
@@ -32,5 +32,5 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 2

--- a/tests/increase-item-depth-existing-sublist/input.yaml
+++ b/tests/increase-item-depth-existing-sublist/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1
             # Sub list
             - kind: block
@@ -23,7 +23,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.1
 
         - kind: block
@@ -34,5 +34,5 @@ document:
               key: '_selection_key'
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 2

--- a/tests/increase-item-depth-fifth/expected.yaml
+++ b/tests/increase-item-depth-fifth/expected.yaml
@@ -10,7 +10,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: "1"
       - kind: block
         type: ul_list
@@ -22,7 +22,7 @@ document:
             type: paragraph
             nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "1.1"
         - kind: block
           type: list_item
@@ -31,7 +31,7 @@ document:
             type: paragraph
             nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "1.2"
         - kind: block
           type: list_item
@@ -40,7 +40,7 @@ document:
             type: paragraph
             nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "1.3"
         - kind: block
           type: list_item
@@ -49,7 +49,7 @@ document:
             type: paragraph
             nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "1.4"
         - kind: block
           type: list_item
@@ -58,5 +58,5 @@ document:
             type: paragraph
             nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "2"

--- a/tests/increase-item-depth-fifth/input.yaml
+++ b/tests/increase-item-depth-fifth/input.yaml
@@ -10,7 +10,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: "1"
       - kind: block
         type: ul_list
@@ -22,7 +22,7 @@ document:
             type: paragraph
             nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "1.1"
         - kind: block
           type: list_item
@@ -31,7 +31,7 @@ document:
             type: paragraph
             nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "1.2"
         - kind: block
           type: list_item
@@ -40,7 +40,7 @@ document:
             type: paragraph
             nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "1.3"
         - kind: block
           type: list_item
@@ -49,7 +49,7 @@ document:
             type: paragraph
             nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "1.4"
     - kind: block
       type: list_item
@@ -59,7 +59,7 @@ document:
         nodes:
         - kind: text
           key: 'cursor'
-          ranges:
+          leaves:
             - text: "2"
 
 selection:

--- a/tests/schema-items-are-list-children/expected.yaml
+++ b/tests/schema-items-are-list-children/expected.yaml
@@ -5,7 +5,7 @@ document:
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: "Orphan"
 
     - kind: block
@@ -18,7 +18,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "Valid item"
 
         - kind: block
@@ -28,5 +28,5 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "Direct child of another item"

--- a/tests/schema-items-are-list-children/input.yaml
+++ b/tests/schema-items-are-list-children/input.yaml
@@ -8,7 +8,7 @@ document:
           type: paragraph
           nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "Orphan"
 
     - kind: block
@@ -21,7 +21,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "Valid item"
         # Item that contains another item
         - kind: block
@@ -34,5 +34,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "Direct child of another item"

--- a/tests/schema-items-contain-blocks-2/expected.yaml
+++ b/tests/schema-items-contain-blocks-2/expected.yaml
@@ -10,16 +10,16 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
                 - kind: inline
                   type: link
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "A link"
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: ""
         - kind: block
           type: list_item
@@ -28,5 +28,5 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "2nd item"

--- a/tests/schema-items-contain-blocks-2/input.yaml
+++ b/tests/schema-items-contain-blocks-2/input.yaml
@@ -7,20 +7,20 @@ document:
           type: list_item
           nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: ""
             - kind: inline
               type: link
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "A link"
             - kind: text
-              ranges:
+              leaves:
                 - text: ""
         - kind: block
           type: list_item
           nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "2nd item"

--- a/tests/schema-items-contain-blocks/expected.yaml
+++ b/tests/schema-items-contain-blocks/expected.yaml
@@ -10,19 +10,19 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "1st"
                 - kind: inline
                   type: link
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "2nd"
                 - kind: block
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "item"
         - kind: block
           type: list_item
@@ -31,5 +31,5 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "2nd item"

--- a/tests/schema-items-contain-blocks/input.yaml
+++ b/tests/schema-items-contain-blocks/input.yaml
@@ -7,26 +7,26 @@ document:
           type: list_item
           nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "1st"
             - kind: inline
               type: link
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "2nd"
             - kind: text
-              ranges:
+              leaves:
                 - text: ""
             - kind: block
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "item"
         - kind: block
           type: list_item
           nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "2nd item"

--- a/tests/schema-join-adjacent-lists-unless-different/expected.yaml
+++ b/tests/schema-join-adjacent-lists-unless-different/expected.yaml
@@ -11,7 +11,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "1.1"
         - kind: block
           type: list_item
@@ -20,7 +20,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "1.2"
     - kind: block
       type: ul_list
@@ -32,7 +32,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "2.1"
         - kind: block
           type: list_item
@@ -41,5 +41,5 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "2.2"

--- a/tests/schema-join-adjacent-lists-unless-different/input.yaml
+++ b/tests/schema-join-adjacent-lists-unless-different/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "1.1"
         - kind: block
           type: list_item
@@ -19,7 +19,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "1.2"
     - kind: block
       type: ul_list
@@ -31,7 +31,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "2.1"
         - kind: block
           type: list_item
@@ -40,5 +40,5 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "2.2"

--- a/tests/schema-join-adjacent-lists/expected.yaml
+++ b/tests/schema-join-adjacent-lists/expected.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "1.1"
         - kind: block
           type: list_item
@@ -19,7 +19,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "1.2"
         - kind: block
           type: list_item
@@ -28,7 +28,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "2.1"
         - kind: block
           type: list_item
@@ -37,7 +37,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "2.2"
         - kind: block
           type: list_item
@@ -46,7 +46,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "3.1"
         - kind: block
           type: list_item
@@ -55,5 +55,5 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "3.2"

--- a/tests/schema-join-adjacent-lists/input.yaml
+++ b/tests/schema-join-adjacent-lists/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "1.1"
         - kind: block
           type: list_item
@@ -19,7 +19,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "1.2"
     - kind: block
       type: ol_list
@@ -31,7 +31,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "2.1"
         - kind: block
           type: list_item
@@ -40,7 +40,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "2.2"
     - kind: block
       type: ol_list
@@ -52,7 +52,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "3.1"
         - kind: block
           type: list_item
@@ -61,5 +61,5 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "3.2"

--- a/tests/schema-lists-contain-items/expected.yaml
+++ b/tests/schema-lists-contain-items/expected.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "1st item"
         - kind: block
           type: list_item
@@ -19,7 +19,7 @@ document:
               type: NOT_AN_ITEM
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "2nd item"
         - kind: block
           type: list_item
@@ -28,5 +28,5 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "3rd item"

--- a/tests/schema-lists-contain-items/input.yaml
+++ b/tests/schema-lists-contain-items/input.yaml
@@ -7,17 +7,17 @@ document:
           type: list_item
           nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "1st item"
         - kind: block
           type: NOT_AN_ITEM
           nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "2nd item"
         - kind: block
           type: list_item
           nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: "3rd item"

--- a/tests/schema-nested-lists/expected.yaml
+++ b/tests/schema-nested-lists/expected.yaml
@@ -12,7 +12,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "Nested list"
             - kind: block
               type: ul_list
@@ -24,7 +24,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: "1.1"
                 - kind: block
                   type: list_item
@@ -33,7 +33,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: "1.2"
         - kind: block
           type: list_item
@@ -42,5 +42,5 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "2"

--- a/tests/schema-nested-lists/input.yaml
+++ b/tests/schema-nested-lists/input.yaml
@@ -12,7 +12,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "Nested list"
             - kind: block
               type: ul_list
@@ -24,7 +24,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: "1.1"
                 - kind: block
                   type: list_item
@@ -33,7 +33,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: "1.2"
         - kind: block
           type: list_item
@@ -42,5 +42,5 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: "2"

--- a/tests/schema-ul-ul-li-li/expected.yaml
+++ b/tests/schema-ul-ul-li-li/expected.yaml
@@ -16,5 +16,5 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: '1st item'

--- a/tests/schema-ul-ul-li-li/input.yaml
+++ b/tests/schema-ul-ul-li-li/input.yaml
@@ -17,12 +17,12 @@ document:
                       nodes:
                         - kind: text
                           key: 'start'
-                          ranges:
+                          leaves:
                             - text: '1st item'
 
 selection:
   anchorKey: 'start'
   anchorOffset: 2
-  focusKey: 'end'
+  focusKey: 'start'
   focusOffset: 4
   isFocused: true

--- a/tests/shift-enter-middle-item/change.js
+++ b/tests/shift-enter-middle-item/change.js
@@ -4,10 +4,12 @@ module.exports = function(plugin, change) {
     const ret = plugin.onKeyDown(
         {
             preventDefault: () => {},
-            stopPropagation: () => {}
+            stopPropagation: () => {},
+            key: 'Enter',
+            shiftKey: true
         },
-        { key: 'enter', isShift: true },
-        change
+        change,
+        {}
     );
 
     expect(ret === null).toBe(true);

--- a/tests/shift-enter-middle-item/input.yaml
+++ b/tests/shift-enter-middle-item/input.yaml
@@ -11,7 +11,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'First item'
 
     - kind: block
@@ -22,7 +22,7 @@ document:
         nodes:
         - kind: text
           key: 'start'
-          ranges:
+          leaves:
             - text: 'Second item'
 
 selection:

--- a/tests/split-item-end/expected.yaml
+++ b/tests/split-item-end/expected.yaml
@@ -10,7 +10,7 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Hello World
             - kind: block
               type: list_item
@@ -19,5 +19,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: ""

--- a/tests/split-item-end/input.yaml
+++ b/tests/split-item-end/input.yaml
@@ -10,5 +10,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Hello World

--- a/tests/split-item-offset-multiple-blocks/expected.yaml
+++ b/tests/split-item-offset-multiple-blocks/expected.yaml
@@ -10,13 +10,13 @@ document:
                   type: heading
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: First block
                 - kind: block
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Split
             - kind: block
               type: list_item
@@ -25,5 +25,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Here

--- a/tests/split-item-offset-multiple-blocks/input.yaml
+++ b/tests/split-item-offset-multiple-blocks/input.yaml
@@ -10,11 +10,11 @@ document:
                   type: heading
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: First block
                 - kind: block
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: SplitHere

--- a/tests/split-item-offset/expected.yaml
+++ b/tests/split-item-offset/expected.yaml
@@ -10,7 +10,7 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: "Hello"
             - kind: block
               type: list_item
@@ -19,5 +19,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: " World"

--- a/tests/split-item-offset/input.yaml
+++ b/tests/split-item-offset/input.yaml
@@ -10,5 +10,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Hello World

--- a/tests/split-item-start/expected.yaml
+++ b/tests/split-item-start/expected.yaml
@@ -10,7 +10,7 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: ""
             - kind: block
               type: list_item
@@ -19,5 +19,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Hello World

--- a/tests/split-item-start/input.yaml
+++ b/tests/split-item-start/input.yaml
@@ -10,5 +10,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Hello World

--- a/tests/split-item-sublist-deep/change.js
+++ b/tests/split-item-sublist-deep/change.js
@@ -20,7 +20,7 @@ module.exports = function(plugin, change) {
         isBackward: false,
         isFocused: false,
         marks: null,
-        kind: 'selection'
+        kind: 'range'
     });
 
     return change;

--- a/tests/split-item-sublist-deep/expected.yaml
+++ b/tests/split-item-sublist-deep/expected.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1
             - kind: block
               type: ol_list
@@ -22,7 +22,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: It
                 - kind: block
                   type: list_item
@@ -31,7 +31,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: em 1.1
                     - kind: block
                       type: ol_list
@@ -43,7 +43,7 @@ document:
                               type: paragraph
                               nodes:
                                 - kind: text
-                                  ranges:
+                                  leaves:
                                     - text: Item 1.1.1
                         - kind: block
                           type: list_item
@@ -52,5 +52,5 @@ document:
                               type: paragraph
                               nodes:
                                 - kind: text
-                                  ranges:
+                                  leaves:
                                     - text: Item 1.1.2

--- a/tests/split-item-sublist-deep/input.yaml
+++ b/tests/split-item-sublist-deep/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1
             - kind: block
               type: ol_list
@@ -23,7 +23,7 @@ document:
                       key: '_selection_key'
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.1 # split here "It|em 1.1"
                     - kind: block
                       type: ol_list
@@ -35,7 +35,7 @@ document:
                               type: paragraph
                               nodes:
                                 - kind: text
-                                  ranges:
+                                  leaves:
                                     - text: Item 1.1.1
                         - kind: block
                           type: list_item
@@ -44,5 +44,5 @@ document:
                               type: paragraph
                               nodes:
                                 - kind: text
-                                  ranges:
+                                  leaves:
                                     - text: Item 1.1.2

--- a/tests/split-item-sublist/expected.yaml
+++ b/tests/split-item-sublist/expected.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: It
         - kind: block
           type: list_item
@@ -19,7 +19,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: em 1
             - kind: block
               type: ol_list
@@ -31,7 +31,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.1
                 - kind: block
                   type: list_item
@@ -40,5 +40,5 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.2

--- a/tests/split-item-sublist/input.yaml
+++ b/tests/split-item-sublist/input.yaml
@@ -11,7 +11,7 @@ document:
               key: '_selection_key'
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1 # split here "It|em 1"
             - kind: block
               type: ol_list
@@ -23,7 +23,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.1
                 - kind: block
                   type: list_item
@@ -32,5 +32,5 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.2

--- a/tests/undo-decrease-item-depth-long-sublist/expected.yaml
+++ b/tests/undo-decrease-item-depth-long-sublist/expected.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1
 
             - kind: block
@@ -23,7 +23,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.1
                 - kind: block
                   type: list_item
@@ -32,5 +32,5 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.2

--- a/tests/undo-decrease-item-depth-long-sublist/input.yaml
+++ b/tests/undo-decrease-item-depth-long-sublist/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1
 
             - kind: block
@@ -24,7 +24,7 @@ document:
                       key: '_selection_key'
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.1
                 - kind: block
                   type: list_item
@@ -33,5 +33,5 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.2

--- a/tests/undo-increase-item-depth-complex/expected.yaml
+++ b/tests/undo-increase-item-depth-complex/expected.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
         - kind: block
           type: list_item
@@ -19,7 +19,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Second item
             - kind: block
               type: ol_list
@@ -31,7 +31,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: First item in the nested list
                 - kind: block
                   type: list_item
@@ -40,5 +40,5 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Second item in the nested list

--- a/tests/undo-increase-item-depth-complex/input.yaml
+++ b/tests/undo-increase-item-depth-complex/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: First item
         - kind: block
           type: list_item
@@ -19,7 +19,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Second item
             - kind: block
               type: ol_list
@@ -31,7 +31,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: First item in the nested list
                 - kind: block
                   type: list_item
@@ -41,5 +41,5 @@ document:
                       key: '_selection_key'
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Second item in the nested list

--- a/tests/undo-split-item-sublist-deep/expected.yaml
+++ b/tests/undo-split-item-sublist-deep/expected.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1
             - kind: block
               type: ol_list
@@ -22,7 +22,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Item 1.1
                     - kind: block
                       type: ol_list
@@ -34,7 +34,7 @@ document:
                               type: paragraph
                               nodes:
                                 - kind: text
-                                  ranges:
+                                  leaves:
                                     - text: Item 1.1.1
                         - kind: block
                           type: list_item
@@ -43,5 +43,5 @@ document:
                               type: paragraph
                               nodes:
                                 - kind: text
-                                  ranges:
+                                  leaves:
                                     - text: Item 1.1.2

--- a/tests/undo-split-item-sublist-deep/input.yaml
+++ b/tests/undo-split-item-sublist-deep/input.yaml
@@ -10,7 +10,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Item 1
             - kind: block
               type: ol_list
@@ -24,7 +24,7 @@ document:
                         - kind: text
                           key: '_selection_key'
                           # split here "It|em 1.1"
-                          ranges:
+                          leaves:
                             - text: Item 1.1
                     - kind: block
                       type: ol_list
@@ -36,7 +36,7 @@ document:
                               type: paragraph
                               nodes:
                                 - kind: text
-                                  ranges:
+                                  leaves:
                                     - text: Item 1.1.1
                         - kind: block
                           type: list_item
@@ -45,5 +45,5 @@ document:
                               type: paragraph
                               nodes:
                                 - kind: text
-                                  ranges:
+                                  leaves:
                                     - text: Item 1.1.2

--- a/tests/undo-unwrap-long-list/expected.yaml
+++ b/tests/undo-unwrap-long-list/expected.yaml
@@ -10,7 +10,7 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Item 1
             - kind: block
               type: list_item
@@ -19,7 +19,7 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Item 2
             - kind: block
               type: list_item
@@ -28,5 +28,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Item 3

--- a/tests/undo-unwrap-long-list/input.yaml
+++ b/tests/undo-unwrap-long-list/input.yaml
@@ -10,7 +10,7 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Item 1
             - kind: block
               type: list_item
@@ -20,7 +20,7 @@ document:
                   key: '_selection_key'
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Item 2
             - kind: block
               type: list_item
@@ -29,5 +29,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Item 3

--- a/tests/undo-wrap-in-list/expected.yaml
+++ b/tests/undo-wrap-in-list/expected.yaml
@@ -4,5 +4,5 @@ document:
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: Hello World

--- a/tests/undo-wrap-in-list/input.yaml
+++ b/tests/undo-wrap-in-list/input.yaml
@@ -4,5 +4,5 @@ document:
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: Hello World

--- a/tests/unwrap-list-multiple-nested/expected.yaml
+++ b/tests/unwrap-list-multiple-nested/expected.yaml
@@ -4,14 +4,14 @@ document:
       type: paragraph
       nodes:
       - kind: text
-        ranges:
+        leaves:
           - text: 'First item'
 
     - kind: block
       type: paragraph
       nodes:
       - kind: text
-        ranges:
+        leaves:
           - text: 'Second item, with nested list'
     - kind: block
       type: ol_list
@@ -23,7 +23,7 @@ document:
           type: paragraph
           nodes:
           - kind: text
-            ranges:
+            leaves:
               - text: 'First item in the nested list'
       - kind: block
         type: list_item
@@ -32,7 +32,7 @@ document:
           type: paragraph
           nodes:
           - kind: text
-            ranges:
+            leaves:
               - text: 'Second item in the nested list'
 
     - kind: block
@@ -45,5 +45,5 @@ document:
           type: paragraph
           nodes:
           - kind: text
-            ranges:
+            leaves:
               - text: 'Third item'

--- a/tests/unwrap-list-multiple-nested/input.yaml
+++ b/tests/unwrap-list-multiple-nested/input.yaml
@@ -12,7 +12,7 @@ document:
         nodes:
         - kind: text
           key: 'start'
-          ranges:
+          leaves:
             - text: 'First item'
 
     - kind: block
@@ -22,7 +22,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'Second item, with nested list'
       - kind: block
         type: ol_list
@@ -35,7 +35,7 @@ document:
             nodes:
             - kind: text
               key: 'end'
-              ranges:
+              leaves:
                 - text: 'First item in the nested list'
         - kind: block
           type: list_item
@@ -44,7 +44,7 @@ document:
             type: paragraph
             nodes:
             - kind: text
-              ranges:
+              leaves:
                 - text: 'Second item in the nested list'
 
 
@@ -55,7 +55,7 @@ document:
         type: paragraph
         nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'Third item'
 
 selection:

--- a/tests/unwrap-list-multiple/expected.yaml
+++ b/tests/unwrap-list-multiple/expected.yaml
@@ -4,25 +4,25 @@ document:
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'Blah blah'
 
     - kind: block
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'First item'
     - kind: block
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'Second item'
 
     - kind: block
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'Blah blah'

--- a/tests/unwrap-list-multiple/input.yaml
+++ b/tests/unwrap-list-multiple/input.yaml
@@ -5,7 +5,7 @@ document:
     type: paragraph
     nodes:
       - kind: text
-        ranges:
+        leaves:
           - text: 'Blah blah'
 
   - kind: block
@@ -19,7 +19,7 @@ document:
             nodes:
               - kind: text
                 key: 'start'
-                ranges:
+                leaves:
                   - text: 'First item'
       - kind: block
         type: list_item
@@ -29,14 +29,14 @@ document:
             nodes:
               - kind: text
                 key: 'end'
-                ranges:
+                leaves:
                   - text: 'Second item'
 
   - kind: block
     type: paragraph
     nodes:
       - kind: text
-        ranges:
+        leaves:
           - text: 'Blah blah'
 
 selection:

--- a/tests/unwrap-list/expected.yaml
+++ b/tests/unwrap-list/expected.yaml
@@ -4,5 +4,5 @@ document:
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: Hello World

--- a/tests/unwrap-list/input.yaml
+++ b/tests/unwrap-list/input.yaml
@@ -10,5 +10,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Hello World

--- a/tests/unwrap-long-list/expected.yaml
+++ b/tests/unwrap-long-list/expected.yaml
@@ -10,13 +10,13 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Item 1
       - kind: block
         type: paragraph
         nodes:
           - kind: text
-            ranges:
+            leaves:
               - text: Item 2
 
       - kind: block
@@ -29,5 +29,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Item 3

--- a/tests/unwrap-long-list/input.yaml
+++ b/tests/unwrap-long-list/input.yaml
@@ -10,7 +10,7 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Item 1
             - kind: block
               type: list_item
@@ -20,7 +20,7 @@ document:
                   nodes:
                     - kind: text
                       key: '_selection_key'
-                      ranges:
+                      leaves:
                         - text: Item 2
             - kind: block
               type: list_item
@@ -29,5 +29,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Item 3

--- a/tests/unwrap-nested-list/expected.yaml
+++ b/tests/unwrap-nested-list/expected.yaml
@@ -4,7 +4,7 @@ document:
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: Item 1
     - kind: block
       type: ol_list
@@ -16,5 +16,5 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: Subtitem 1

--- a/tests/unwrap-nested-list/input.yaml
+++ b/tests/unwrap-nested-list/input.yaml
@@ -11,7 +11,7 @@ document:
               nodes:
                 - kind: text
                   key: '_selection_key'
-                  ranges:
+                  leaves:
                     - text: Item 1
             - kind: block
               type: ol_list
@@ -23,5 +23,5 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: Subtitem 1

--- a/tests/wrap-in-list-list-with-data/expected.yaml
+++ b/tests/wrap-in-list-list-with-data/expected.yaml
@@ -4,7 +4,7 @@ document:
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'Blah blah'
 
     - kind: block
@@ -21,7 +21,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: 'First item'
             - kind: block
               type: ul_list
@@ -33,7 +33,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: 'Subitem'
 
         - kind: block
@@ -43,7 +43,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: 'Second item'
 
         - kind: block
@@ -53,5 +53,5 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: 'Blah blah'

--- a/tests/wrap-in-list-list-with-data/input.yaml
+++ b/tests/wrap-in-list-list-with-data/input.yaml
@@ -6,7 +6,7 @@ document:
     type: paragraph
     nodes:
       - kind: text
-        ranges:
+        leaves:
           - text: 'Blah blah'
 
   - kind: block
@@ -23,7 +23,7 @@ document:
             nodes:
               - kind: text
                 key: 'start'
-                ranges:
+                leaves:
                   - text: 'First item'
           - kind: block
             type: ul_list
@@ -35,7 +35,7 @@ document:
                     type: paragraph
                     nodes:
                       - kind: text
-                        ranges:
+                        leaves:
                           - text: 'Subitem'
       - kind: block
         type: list_item
@@ -44,7 +44,7 @@ document:
             type: paragraph
             nodes:
               - kind: text
-                ranges:
+                leaves:
                   - text: 'Second item'
 
   - kind: block
@@ -52,7 +52,7 @@ document:
     nodes:
       - kind: text
         key: 'end'
-        ranges:
+        leaves:
           - text: 'Blah blah'
 
 selection:

--- a/tests/wrap-in-list-list/expected.yaml
+++ b/tests/wrap-in-list-list/expected.yaml
@@ -4,7 +4,7 @@ document:
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'Blah blah'
 
     - kind: block
@@ -18,7 +18,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: 'First item'
             - kind: block
               type: ul_list
@@ -30,7 +30,7 @@ document:
                       type: paragraph
                       nodes:
                         - kind: text
-                          ranges:
+                          leaves:
                             - text: 'Subitem'
 
         - kind: block
@@ -40,7 +40,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: 'Second item'
 
         - kind: block
@@ -50,5 +50,5 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: 'Blah blah'

--- a/tests/wrap-in-list-list/input.yaml
+++ b/tests/wrap-in-list-list/input.yaml
@@ -5,7 +5,7 @@ document:
     type: paragraph
     nodes:
       - kind: text
-        ranges:
+        leaves:
           - text: 'Blah blah'
 
   - kind: block
@@ -19,7 +19,7 @@ document:
             nodes:
               - kind: text
                 key: 'start'
-                ranges:
+                leaves:
                   - text: 'First item'
           - kind: block
             type: ul_list
@@ -31,7 +31,7 @@ document:
                     type: paragraph
                     nodes:
                       - kind: text
-                        ranges:
+                        leaves:
                           - text: 'Subitem'
       - kind: block
         type: list_item
@@ -40,7 +40,7 @@ document:
             type: paragraph
             nodes:
               - kind: text
-                ranges:
+                leaves:
                   - text: 'Second item'
 
   - kind: block
@@ -48,7 +48,7 @@ document:
     nodes:
       - kind: text
         key: 'end'
-        ranges:
+        leaves:
           - text: 'Blah blah'
 
 selection:

--- a/tests/wrap-in-list-multiple-with-data/expected.yaml
+++ b/tests/wrap-in-list-multiple-with-data/expected.yaml
@@ -4,7 +4,7 @@ document:
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'Blah blah'
 
     - kind: block
@@ -20,7 +20,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: 'First item'
         - kind: block
           type: list_item
@@ -29,12 +29,12 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: 'Second item'
 
     - kind: block
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'Blah blah'

--- a/tests/wrap-in-list-multiple-with-data/input.yaml
+++ b/tests/wrap-in-list-multiple-with-data/input.yaml
@@ -6,7 +6,7 @@ document:
     type: paragraph
     nodes:
       - kind: text
-        ranges:
+        leaves:
           - text: 'Blah blah'
 
   - kind: block
@@ -14,7 +14,7 @@ document:
     nodes:
       - kind: text
         key: 'start'
-        ranges:
+        leaves:
           - text: 'First item'
 
   - kind: block
@@ -22,14 +22,14 @@ document:
     nodes:
       - kind: text
         key: 'end'
-        ranges:
+        leaves:
           - text: 'Second item'
 
   - kind: block
     type: paragraph
     nodes:
       - kind: text
-        ranges:
+        leaves:
           - text: 'Blah blah'
 
 selection:

--- a/tests/wrap-in-list-multiple/expected.yaml
+++ b/tests/wrap-in-list-multiple/expected.yaml
@@ -4,7 +4,7 @@ document:
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'Blah blah'
 
     - kind: block
@@ -17,7 +17,7 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: 'First item'
         - kind: block
           type: list_item
@@ -26,12 +26,12 @@ document:
               type: paragraph
               nodes:
                 - kind: text
-                  ranges:
+                  leaves:
                     - text: 'Second item'
 
     - kind: block
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: 'Blah blah'

--- a/tests/wrap-in-list-multiple/input.yaml
+++ b/tests/wrap-in-list-multiple/input.yaml
@@ -6,7 +6,7 @@ document:
     type: paragraph
     nodes:
       - kind: text
-        ranges:
+        leaves:
           - text: 'Blah blah'
 
   - kind: block
@@ -14,7 +14,7 @@ document:
     nodes:
       - kind: text
         key: 'start'
-        ranges:
+        leaves:
           - text: 'First item'
 
   - kind: block
@@ -22,14 +22,14 @@ document:
     nodes:
       - kind: text
         key: 'end'
-        ranges:
+        leaves:
           - text: 'Second item'
 
   - kind: block
     type: paragraph
     nodes:
       - kind: text
-        ranges:
+        leaves:
           - text: 'Blah blah'
 
 selection:

--- a/tests/wrap-in-list-with-data/expected.yaml
+++ b/tests/wrap-in-list-with-data/expected.yaml
@@ -13,5 +13,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Hello World

--- a/tests/wrap-in-list-with-data/input.yaml
+++ b/tests/wrap-in-list-with-data/input.yaml
@@ -4,5 +4,5 @@ document:
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: Hello World

--- a/tests/wrap-in-list/expected.yaml
+++ b/tests/wrap-in-list/expected.yaml
@@ -10,5 +10,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Hello World

--- a/tests/wrap-in-list/input.yaml
+++ b/tests/wrap-in-list/input.yaml
@@ -4,5 +4,5 @@ document:
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: Hello World

--- a/tests/wrap-in-ol/expected.yaml
+++ b/tests/wrap-in-ol/expected.yaml
@@ -10,5 +10,5 @@ document:
                   type: paragraph
                   nodes:
                     - kind: text
-                      ranges:
+                      leaves:
                         - text: Hello World

--- a/tests/wrap-in-ol/input.yaml
+++ b/tests/wrap-in-ol/input.yaml
@@ -4,5 +4,5 @@ document:
       type: paragraph
       nodes:
         - kind: text
-          ranges:
+          leaves:
             - text: Hello World

--- a/yarn.lock
+++ b/yarn.lock
@@ -1647,16 +1647,16 @@ fast-levenshtein@~2.0.4:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.5.tgz#bd33145744519ab1c36c3ee9f31f08e9079b67f2"
 
-fbjs@^0.8.4:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.5.tgz#f69ba8a876096cb1b9bffe4d7c1e71c19d39d008"
+fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
     core-js "^1.0.0"
-    immutable "^3.7.6"
     isomorphic-fetch "^2.1.1"
     loose-envify "^1.0.0"
     object-assign "^4.1.0"
     promise "^7.1.1"
+    setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
 fbjs@^0.8.9:
@@ -2041,9 +2041,9 @@ ignore@^3.1.5:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.2.0.tgz#8d88f03c3002a0ac52114db25d2c673b0bf1e435"
 
-immutable@^3.7.6:
-  version "3.8.1"
-  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.1.tgz#200807f11ab0f72710ea485542de088075f68cd2"
+immutable@^3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
 
 imurmurhash@^0.1.4:
   version "0.1.4"
@@ -2210,6 +2210,10 @@ is-glob@^2.0.0, is-glob@^2.0.1:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-2.0.1.tgz#d096f926a3ded5600f3fdfd91198cb0888c2d863"
   dependencies:
     is-extglob "^1.0.0"
+
+is-hotkey@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-hotkey/-/is-hotkey-0.1.1.tgz#b279a2fd108391be9aa93c6cb317f50357da549a"
 
 is-in-browser@^1.1.3:
   version "1.1.3"
@@ -2723,6 +2727,10 @@ object-assign@^4.0.0, object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
 
+object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
 object-inspect@^1.1.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.2.1.tgz#3b62226eb8f6d441751c7d8f22a20ff80ac9dc3f"
@@ -2937,6 +2945,14 @@ prop-types@^15.5.8:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 public-encrypt@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/public-encrypt/-/public-encrypt-4.0.0.tgz#39f699f3a46560dd5ebacbca693caf7c65c18cc6"
@@ -3010,9 +3026,18 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
 
-react-dom@^15.3.0:
-  version "15.3.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.3.2.tgz#c46b0aa5380d7b838e7a59c4a7beff2ed315531f"
+react-dom@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
+react-immutable-proptypes@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-immutable-proptypes/-/react-immutable-proptypes-2.1.0.tgz#023d6f39bb15c97c071e9e60d00d136eac5fa0b4"
 
 react-portal@^3.1.0:
   version "3.1.0"
@@ -3020,13 +3045,14 @@ react-portal@^3.1.0:
   dependencies:
     prop-types "^15.5.8"
 
-react@^15.3.0:
-  version "15.3.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.3.2.tgz#a7bccd2fee8af126b0317e222c28d1d54528d09e"
+react@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 read-metadata@^1.0.0:
   version "1.0.0"
@@ -3278,46 +3304,48 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
 
-slate-base64-serializer@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/slate-base64-serializer/-/slate-base64-serializer-0.1.5.tgz#6206f2df41476af44b09c30d5a5b30dd79580363"
+slate-base64-serializer@^0.1.18:
+  version "0.1.18"
+  resolved "https://registry.yarnpkg.com/slate-base64-serializer/-/slate-base64-serializer-0.1.18.tgz#1c57c8bdf3754adae085fa7f7537a99f818fc4fd"
 
-slate-dev-logger@^0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.6.tgz#feaa51804933388e64d3803eecc736062a2c7800"
+slate-dev-logger@^0.1.19:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/slate-dev-logger/-/slate-dev-logger-0.1.19.tgz#ac7e48219d575ed317800d13dc3e1aac1927cb47"
 
-slate-plain-serializer@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/slate-plain-serializer/-/slate-plain-serializer-0.1.5.tgz#58d1cb22e531b08f23ba2e8659bf59baabfa2391"
+slate-plain-serializer@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/slate-plain-serializer/-/slate-plain-serializer-0.2.4.tgz#42599ab1e1b0e40b29179fb255ad3a596fe6f88f"
   dependencies:
-    slate-dev-logger "^0.1.6"
+    slate-dev-logger "^0.1.19"
 
-slate-prop-types@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/slate-prop-types/-/slate-prop-types-0.1.5.tgz#98ead5741d2cb7ebfe67754c9c7c26798b6de659"
+slate-prop-types@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/slate-prop-types/-/slate-prop-types-0.2.4.tgz#f6ddafd940dc4b92eaff814de4c5687c1a9de8aa"
   dependencies:
-    slate-dev-logger "^0.1.6"
+    slate-dev-logger "^0.1.19"
 
-slate-react@^0.1.5:
-  version "0.1.5"
-  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.1.5.tgz#8681c64dd8db6e0323b93156331aa56c3fdf0fe2"
+slate-react@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/slate-react/-/slate-react-0.7.2.tgz#e8a9f2b33a3f42a445f6f88ed6821b06335d9e91"
   dependencies:
     debug "^2.3.2"
     get-window "^1.1.1"
+    is-hotkey "^0.1.1"
     is-in-browser "^1.1.3"
     is-window "^1.0.2"
     keycode "^2.1.2"
     prop-types "^15.5.8"
+    react-immutable-proptypes "^2.1.0"
     react-portal "^3.1.0"
     selection-is-backward "^1.0.0"
-    slate-base64-serializer "^0.1.5"
-    slate-dev-logger "^0.1.6"
-    slate-plain-serializer "^0.1.5"
-    slate-prop-types "^0.1.5"
+    slate-base64-serializer "^0.1.18"
+    slate-dev-logger "^0.1.19"
+    slate-plain-serializer "^0.2.4"
+    slate-prop-types "^0.2.4"
 
-slate@^0.24.0:
-  version "0.24.5"
-  resolved "https://registry.yarnpkg.com/slate/-/slate-0.24.5.tgz#3bfd9827b55aa8152638c102fcde0a285523af7e"
+slate@^0.27.4:
+  version "0.27.4"
+  resolved "https://registry.yarnpkg.com/slate/-/slate-0.27.4.tgz#46ad256e8e26adac33728d72017a68ca023a5302"
   dependencies:
     debug "^2.3.2"
     direction "^0.1.5"
@@ -3326,7 +3354,7 @@ slate@^0.24.0:
     is-empty "^1.0.0"
     is-plain-object "^2.0.4"
     lodash "^4.17.4"
-    slate-dev-logger "^0.1.6"
+    slate-dev-logger "^0.1.19"
     type-of "^2.0.1"
 
 slice-ansi@0.0.4:


### PR DESCRIPTION
A few of the bigger changes: 

* Move to JS class syntax
* `ranges` is now `leaves`
* plugin functions now take `(event, change, editor)` -- use `event` to get keypresses instead
