### PR TITLE
Fix npm warning when using slate-0.3x

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./dist/index.js",
   "peerDependencies": {
     "immutable": "^3.8.2",
-    "slate": "^0.29.0"
+    "slate": ">=0.29.0 <0.32.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -31,7 +31,7 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "read-metadata": "^1.0.0",
-    "slate": "^0.29.0",
+    "slate": "^0.31.8",
     "slate-hyperscript": "^0.4.6",
     "slate-react": "^0.10.0",
     "stringify": "^5.1.0"


### PR DESCRIPTION
Just like https://github.com/GitbookIO/slate-edit-table/pull/58

Could you make a small version bump after merging?

BTW, this small version may be the last version of 0.10.x, because slate-0.32 made a breaking name change by renaming `kind` to `object`