### PR TITLE
Merging lists will move nodes instead of inserting them

### DIFF
--- a/lib/changes/wrapInList.js
+++ b/lib/changes/wrapInList.js
@@ -41,7 +41,7 @@ function wrapInList(
         }
     });
 
-    return change;
+    return change.normalize();
 }
 
 /**

--- a/lib/validation/validateNode.js
+++ b/lib/validation/validateNode.js
@@ -45,10 +45,10 @@ function joinAdjacentLists(opts: Options, node: Node): void | Normalizer {
                 second.key
             );
             updatedSecond.nodes.forEach((secondNode, index) => {
-                change.insertNodeByKey(
+                change.moveNodeByKey(
+                    secondNode.key,
                     first.key,
                     first.nodes.size + index,
-                    secondNode,
                     { normalize: false }
                 );
             });


### PR DESCRIPTION
This is closer to what we're actually doing, and it prevents the selection from moving to the wrong place.