### PR TITLE
onEnter while expanded should delete selection first

### DIFF
--- a/lib/handlers/onEnter.js
+++ b/lib/handlers/onEnter.js
@@ -32,6 +32,11 @@ function onEnter(
         return undefined;
     }
 
+    // If expanded, delete first.
+    if (value.isExpanded) {
+        change.delete();
+    }
+
     event.preventDefault();
     if (currentItem.isEmpty) {
         // Block is empty, we exit the list


### PR DESCRIPTION
Currently hitting enter while selection is expanded, the plugin simply splits the list but preserves the selection. Not sure whether this was an intended behavior or a bug, but this is at odds with most rich text editors where selection is deleted in this case.

This patch fixes the following issue observed in the screenshot below:

![6ok8loeyue](https://user-images.githubusercontent.com/4471723/35771873-9649eaa0-0901-11e8-93b7-f2ca06821fdc.gif)
