### PR TITLE
Add option to control merging of adjacent lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/GitbookIO/slate-edit-list/compare/0.11.0...HEAD
+[Unreleased]: https://github.com/GitbookIO/slate-edit-list/compare/0.12.0...HEAD
+
+## 0.12.0 - 2018-08-03
+
+- Add `canMerge` option to control which adjacent lists can
+  be merged automatically through normalization.
 
 ## 0.11.2 - 2018-02-06
+
 ## 0.11.1 - 2018-02-06
 
 - Fixed build

--- a/README.md
+++ b/README.md
@@ -45,9 +45,11 @@ const plugins = [
 
 This plugin accepts options to redefine the following block types:
 
-- `<String> types=["ol_list", "ul_list"]` — the array of possible types for list containers. First value will be used as default.
-- `<String> typeItem="list_item"` — type for list items.
-- `<String> typeDefault="paragraph"` — type for default block in list items.
+- `types: string = ["ol_list", "ul_list"]` — the array of possible types for list containers. First value will be used as default.
+- `typeItem: string = "list_item"` — type for list items.
+- `typeDefault: string = "paragraph"` — type for default block in list items.
+- `canMerge: (Node, Node) => boolean` — controls which list can be merged automatically (for example when they are adjacent). Defaults to merging list with identical types
+
 
 #### Assumption about the schema
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,10 +1,12 @@
 // @flow
+import type { Node } from 'slate';
 import { Record } from 'immutable';
 
 export type OptionsFormat = {
     types?: string[],
     typeItem?: string,
-    typeDefault?: string
+    typeDefault?: string,
+    canMerge?: (listA: Node, listB: Node) => boolean
 };
 
 /**
@@ -13,7 +15,8 @@ export type OptionsFormat = {
 class Options extends Record({
     types: ['ul_list', 'ol_list'],
     typeItem: 'list_item',
-    typeDefault: 'paragraph'
+    typeDefault: 'paragraph',
+    canMerge: (a: Node, b: Node) => a.type === b.type
 }) {
     // The possibles types for list containers
     types: string[];
@@ -21,6 +24,8 @@ class Options extends Record({
     typeItem: string;
     // The type of default block in items
     typeDefault: string;
+    // You can control here the automatic merging of adjacent lists
+    canMerge: (listA: Node, listB: Node) => boolean;
 }
 
 export default Options;

--- a/lib/validation/validateNode.js
+++ b/lib/validation/validateNode.js
@@ -25,7 +25,7 @@ function joinAdjacentLists(opts: Options, node: Node): void | Normalizer {
         .map((child, i) => {
             if (!isList(opts, child)) return null;
             const next = node.nodes.get(i + 1);
-            if (!next || next.type !== child.type) return null;
+            if (!next || !opts.canMerge(child, next)) return null;
             return [child, next];
         })
         .filter(Boolean);


### PR DESCRIPTION
This adds a `canMerge` option to control the automatic merging of adjacent lists.