### PR TITLE
Add `type` param to `isSelectionInList`

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,9 +114,9 @@ nodes:
 
 `slate-edit-list` exports utilities and transforms:
 
-#### `plugin.utils.isSelectionInList(value: Value) => Boolean`
+#### `plugin.utils.isSelectionInList(value: Value, type?: string) => Boolean`
 
-Return true if selection is inside a list (and it can be unwrap).
+Return true if selection is inside a list (and it can be unwrap). Optional param `type` can be supplied to deduce whether list is of specified type.
 
 #### `plugin.utils.isList(node: Node) => Boolean`
 

--- a/lib/utils/isSelectionInList.js
+++ b/lib/utils/isSelectionInList.js
@@ -3,12 +3,26 @@ import { type Value } from 'slate';
 
 import type Options from '../options';
 import getItemsAtRange from './getItemsAtRange';
+import getListForItem from './getListForItem';
 
 /**
  * True if selection is inside a list (and can be unwrapped)
  */
-function isSelectionInList(opts: Options, value: Value): boolean {
-    return !getItemsAtRange(opts, value).isEmpty();
+function isSelectionInList(
+    opts: Options,
+    value: Value,
+    type?: string
+): boolean {
+    const items = getItemsAtRange(opts, value);
+    if (type) {
+        if (!items.isEmpty()) {
+            return (
+                getListForItem(opts, value, items.first()).get('type') === type
+            );
+        }
+        return false;
+    }
+    return !items.isEmpty();
 }
 
 export default isSelectionInList;

--- a/lib/utils/isSelectionInList.js
+++ b/lib/utils/isSelectionInList.js
@@ -14,15 +14,12 @@ function isSelectionInList(
     type?: string
 ): boolean {
     const items = getItemsAtRange(opts, value);
-    if (type) {
-        if (!items.isEmpty()) {
-            return (
-                getListForItem(opts, value, items.first()).get('type') === type
-            );
-        }
-        return false;
-    }
-    return !items.isEmpty();
+    return (
+        !items.isEmpty() &&
+        // Check the type of the list if needed
+        (!type ||
+            getListForItem(opts, value, items.first()).get('type') === type)
+    );
 }
 
 export default isSelectionInList;


### PR DESCRIPTION
Title pretty much says it but this PR adds an optional `type` param to `isSelectionIsList` for checking if the list if of the specified type. Should close #72